### PR TITLE
feat: implement recursive watch folder with subfolder-to-collection mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A powerful Zotero 8 plugin that automatically monitors a folder for new files an
 
 ### Phase 1: Auto-Import
 - **Watch Folder Monitoring** - Automatically detect new PDF files in a designated folder
+- **Recursive Subfolder Import** - Automatically scan subfolders and map them to Zotero collections (e.g., `WatchFolder/Research/AI` → `TargetCollection/Research/AI`)
 - **Automatic Metadata Retrieval** - Fetch metadata from online sources for imported PDFs
 - **Smart File Renaming** - Rename files based on metadata using customizable patterns (e.g., `{firstCreator} - {year} - {title}`)
 - **First-Run Detection** - Option to import existing files when first configured
@@ -77,7 +78,7 @@ After installation, configure the plugin in `Edit` → `Settings` → `Watch Fol
 
 ```bash
 # Clone the repository
-git clone https://github.com/josesiqueira/zotero-watch-folder-zotero8.git
+git clone https://github.com/stark1tty/zotero-watch-folder-zotero8.git
 cd zotero-watch-folder-zotero8
 
 # Install dependencies

--- a/content/fileImporter.mjs
+++ b/content/fileImporter.mjs
@@ -5,14 +5,14 @@
  * stored (copied) and linked import modes.
  */
 
-import { getPref, getOrCreateTargetCollection } from './utils.mjs';
+import { getPref, getOrCreateTargetCollection, getOrCreateCollectionPath } from './utils.mjs';
 
 /**
  * Import a file into Zotero
  * @param {string} filePath - Full path to the file
  * @param {Object} options - Import options
  * @param {number} [options.libraryID] - Target library (default: user library)
- * @param {string} [options.collectionName] - Target collection name
+ * @param {string} [options.collectionName] - Target collection name (can be a path)
  * @param {string} [options.importMode] - 'stored' or 'linked'
  * @returns {Promise<Zotero.Item>} - The created attachment item
  */
@@ -32,8 +32,13 @@ export async function importFile(filePath, options = {}) {
   const filename = getFilename(filePath);
   Zotero.debug(`[WatchFolder] Importing file: ${filename} (mode: ${importMode})`);
 
-  // 2. Get or create target collection
-  const collection = await getOrCreateTargetCollection(collectionName, libraryID);
+  // 2. Get or create target collection (supporting paths)
+  let collection;
+  if (collectionName.includes('/')) {
+    collection = await getOrCreateCollectionPath(collectionName, libraryID);
+  } else {
+    collection = await getOrCreateTargetCollection(collectionName, libraryID);
+  }
   const collectionID = collection ? collection.id : null;
   const collections = collectionID ? [collectionID] : [];
 
@@ -127,14 +132,14 @@ export async function handlePostImportAction(filePath, action = null) {
 
 /**
  * Import multiple files in batch
- * @param {string[]} filePaths - Array of file paths
+ * @param {string[]|Array<{path: string, collection: string}>} files - Array of file paths or objects
  * @param {Object} options - Import options
  * @param {Function} [options.onProgress] - Progress callback (current, total)
  * @param {number} [options.delayBetween] - Delay between imports in ms
  * @param {boolean} [options.handlePostImport] - Whether to handle post-import action
  * @returns {Promise<{success: Zotero.Item[], failed: {path: string, error: string}[]}>}
  */
-export async function importBatch(filePaths, options = {}) {
+export async function importBatch(files, options = {}) {
   const {
     onProgress = () => {},
     delayBetween = 500,
@@ -147,15 +152,17 @@ export async function importBatch(filePaths, options = {}) {
     failed: []
   };
 
-  Zotero.debug(`[WatchFolder] Starting batch import of ${filePaths.length} files`);
+  Zotero.debug(`[WatchFolder] Starting batch import of ${files.length} files`);
 
-  for (let i = 0; i < filePaths.length; i++) {
-    const filePath = filePaths[i];
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i];
+    const filePath = typeof file === 'string' ? file : file.path;
+    const collectionName = typeof file === 'object' ? file.collection : (importOptions.collectionName || getPref('targetCollection') || 'Inbox');
     const filename = getFilename(filePath);
 
     try {
       // Import the file
-      const item = await importFile(filePath, importOptions);
+      const item = await importFile(filePath, { ...importOptions, collectionName });
       results.success.push(item);
 
       // Handle post-import action (only for stored imports, not linked)

--- a/content/fileImporter.mjs
+++ b/content/fileImporter.mjs
@@ -103,20 +103,27 @@ export async function handlePostImportAction(filePath, action = null) {
       break;
 
     case 'move':
-      // Move to 'imported' subfolder
+      // Move to watchRoot/imported/, mirroring the subfolder structure
       try {
-        const parentDir = PathUtils.parent(filePath);
-        const importedDir = PathUtils.join(parentDir, 'imported');
+        const watchRoot = getPref('sourcePath');
+        let destPath;
 
-        // Create subfolder if not exists
-        const dirExists = await IOUtils.exists(importedDir);
-        if (!dirExists) {
-          await IOUtils.makeDirectory(importedDir, { createAncestors: true });
-          Zotero.debug(`[WatchFolder] Created 'imported' subfolder: ${importedDir}`);
+        if (watchRoot && filePath.startsWith(watchRoot)) {
+          const importedBaseDir = PathUtils.join(watchRoot, 'imported');
+          const relativePath = filePath.substring(watchRoot.length).replace(/^[/\\]/, '');
+          destPath = PathUtils.join(importedBaseDir, relativePath);
+        } else {
+          // Fallback: put in 'imported' folder next to the file
+          destPath = PathUtils.join(PathUtils.parent(filePath), 'imported', filename);
         }
 
-        // Move the file
-        const destPath = PathUtils.join(importedDir, filename);
+        const destDir = PathUtils.parent(destPath);
+        const dirExists = await IOUtils.exists(destDir);
+        if (!dirExists) {
+          await IOUtils.makeDirectory(destDir, { createAncestors: true });
+          Zotero.debug(`[WatchFolder] Created directory: ${destDir}`);
+        }
+
         await IOUtils.move(filePath, destPath);
         Zotero.debug(`[WatchFolder] Moved file to: ${destPath}`);
       } catch (error) {

--- a/content/fileScanner.mjs
+++ b/content/fileScanner.mjs
@@ -115,6 +115,11 @@ export async function scanFolderRecursive(folderPath, maxDepth = 10) {
                 const info = await IOUtils.stat(childPath);
 
                 if (info.type === 'directory') {
+                    // Skip the 'imported' folder to avoid re-processing moved files
+                    if (PathUtils.filename(childPath) === 'imported') {
+                        Zotero.debug(`[Watch Folder] scanFolderRecursive: Skipping 'imported' folder: ${childPath}`);
+                        continue;
+                    }
                     // Recursively scan subdirectories
                     const subFiles = await scanFolderRecursive(childPath, maxDepth - 1);
                     files.push(...subFiles);

--- a/content/firstRunHandler.mjs
+++ b/content/firstRunHandler.mjs
@@ -6,7 +6,7 @@
  */
 
 import { getPref, setPref } from './utils.mjs';
-import { scanFolder } from './fileScanner.mjs';
+import { scanFolder, scanFolderRecursive } from './fileScanner.mjs';
 import { importBatch } from './fileImporter.mjs';
 import { getTrackingStore } from './trackingStore.mjs';
 
@@ -61,7 +61,7 @@ export async function getExistingFilesCount() {
   }
 
   try {
-    const files = await scanFolder(sourcePath);
+    const files = await scanFolderRecursive(sourcePath);
     return { count: files.length, files };
   } catch (error) {
     Zotero.debug(`[WatchFolder] Error scanning for existing files: ${error.message}`);
@@ -149,11 +149,26 @@ export async function importExistingFiles(window, files) {
 
   let cancelled = false;
 
-  // Extract file paths from file objects
-  const filePaths = files.map(f => f.path);
+  const sourcePath = getPref('sourcePath');
+  const baseTarget = getPref('targetCollection') || 'Inbox';
+
+  // Extract file paths and collections from file objects
+  const filesToImport = files.map(f => {
+    let collection = baseTarget;
+    if (f.path.startsWith(sourcePath)) {
+        let relative = f.path.substring(sourcePath.length);
+        if (relative.startsWith('/') || relative.startsWith('\\')) relative = relative.substring(1);
+        const parts = relative.split(/[/\\]/);
+        parts.pop(); // filename
+        if (parts.length > 0) {
+            collection = baseTarget + '/' + parts.join('/');
+        }
+    }
+    return { path: f.path, collection };
+  });
 
   // Import with progress callback
-  const results = await importBatch(filePaths, {
+  const results = await importBatch(filesToImport, {
     onProgress: (current, total) => {
       if (cancelled) return;
       itemProgress.setText(`${current} / ${total}`);

--- a/content/utils.mjs
+++ b/content/utils.mjs
@@ -135,6 +135,7 @@ export async function getOrCreateTargetCollection(collectionName, libraryID = Zo
  * @returns {Promise<Zotero.Collection|null>} The leaf collection
  */
 export async function getOrCreateCollectionPath(path, libraryID = Zotero.Libraries.userLibraryID) {
+  Zotero.debug(`[WatchFolder] Attempting to get/create collection path: ${path}`);
   if (!path || path.trim() === '') return null;
 
   const parts = path.split('/').filter(p => p.trim() !== '');
@@ -143,11 +144,13 @@ export async function getOrCreateCollectionPath(path, libraryID = Zotero.Librari
 
   for (const name of parts) {
     try {
+      Zotero.debug(`[WatchFolder] Looking for collection: "${name}" under parent: ${parentID || 'root'}`);
       // Look for existing child collection
       const children = Zotero.Collections.getByParent(parentID, libraryID);
       let found = false;
       for (const col of children) {
         if (col.name === name) {
+          Zotero.debug(`[WatchFolder] Found existing collection: "${name}" (ID: ${col.id})`);
           currentCollection = col;
           parentID = col.id;
           found = true;
@@ -156,6 +159,7 @@ export async function getOrCreateCollectionPath(path, libraryID = Zotero.Librari
       }
 
       if (!found) {
+        Zotero.debug(`[WatchFolder] Collection "${name}" not found, creating it...`);
         // Create new child collection
         const col = new Zotero.Collection();
         col.libraryID = libraryID;
@@ -164,10 +168,10 @@ export async function getOrCreateCollectionPath(path, libraryID = Zotero.Librari
         await col.saveTx();
         currentCollection = col;
         parentID = col.id;
-        Zotero.debug(`[WatchFolder] Created collection: ${name} under parent ${parentID || 'root'}`);
+        Zotero.debug(`[WatchFolder] Successfully created collection: "${name}" (ID: ${parentID})`);
       }
     } catch (e) {
-      Zotero.logError(`[WatchFolder] Error in getOrCreateCollectionPath for "${name}": ${e.message}`);
+      Zotero.logError(`[WatchFolder] CRITICAL ERROR in getOrCreateCollectionPath for "${name}": ${e.message}`);
       return null;
     }
   }

--- a/content/utils.mjs
+++ b/content/utils.mjs
@@ -139,32 +139,37 @@ export async function getOrCreateCollectionPath(path, libraryID = Zotero.Librari
   if (!path || path.trim() === '') return null;
 
   const parts = path.split('/').filter(p => p.trim() !== '');
-  let parentID = null;
+  let parentID = null; // null = root level
   let currentCollection = null;
 
   for (const name of parts) {
     try {
       Zotero.debug(`[WatchFolder] Looking for collection: "${name}" under parent: ${parentID || 'root'}`);
-      // Look for existing child collection
-      const children = Zotero.Collections.getByParent(parentID, libraryID);
-      let found = false;
-      for (const col of children) {
-        if (col.name === name) {
-          Zotero.debug(`[WatchFolder] Found existing collection: "${name}" (ID: ${col.id})`);
-          currentCollection = col;
-          parentID = col.id;
-          found = true;
-          break;
-        }
+
+      // For root level use getByLibrary (getByParent(false) is unreliable);
+      // for nested levels use getByParent with the numeric parent ID
+      let candidates;
+      if (parentID === null) {
+        candidates = Zotero.Collections.getByLibrary(libraryID).filter(col => !col.parentID);
+      } else {
+        candidates = Zotero.Collections.getByParent(parentID, libraryID);
       }
 
-      if (!found) {
+      const found = candidates.find(col => col.name === name);
+
+      if (found) {
+        Zotero.debug(`[WatchFolder] Found existing collection: "${name}" (ID: ${found.id})`);
+        currentCollection = found;
+        parentID = found.id;
+      } else {
         Zotero.debug(`[WatchFolder] Collection "${name}" not found, creating it...`);
-        // Create new child collection
         const col = new Zotero.Collection();
         col.libraryID = libraryID;
         col.name = name;
-        col.parentID = parentID;
+        // Only set parentID for non-root — setting it to null/false clears libraryID internally
+        if (parentID !== null) {
+          col.parentID = parentID;
+        }
         await col.saveTx();
         currentCollection = col;
         parentID = col.id;

--- a/content/utils.mjs
+++ b/content/utils.mjs
@@ -127,3 +127,50 @@ export async function getOrCreateTargetCollection(collectionName, libraryID = Zo
     return null;
   }
 }
+
+/**
+ * Get or create a path of nested collections
+ * @param {string} path - Slash-separated collection path (e.g. "Inbox/Subfolder")
+ * @param {number} [libraryID] - Library ID
+ * @returns {Promise<Zotero.Collection|null>} The leaf collection
+ */
+export async function getOrCreateCollectionPath(path, libraryID = Zotero.Libraries.userLibraryID) {
+  if (!path || path.trim() === '') return null;
+
+  const parts = path.split('/').filter(p => p.trim() !== '');
+  let parentID = null;
+  let currentCollection = null;
+
+  for (const name of parts) {
+    try {
+      // Look for existing child collection
+      const children = Zotero.Collections.getByParent(parentID, libraryID);
+      let found = false;
+      for (const col of children) {
+        if (col.name === name) {
+          currentCollection = col;
+          parentID = col.id;
+          found = true;
+          break;
+        }
+      }
+
+      if (!found) {
+        // Create new child collection
+        const col = new Zotero.Collection();
+        col.libraryID = libraryID;
+        col.name = name;
+        col.parentID = parentID;
+        await col.saveTx();
+        currentCollection = col;
+        parentID = col.id;
+        Zotero.debug(`[WatchFolder] Created collection: ${name} under parent ${parentID || 'root'}`);
+      }
+    } catch (e) {
+      Zotero.logError(`[WatchFolder] Error in getOrCreateCollectionPath for "${name}": ${e.message}`);
+      return null;
+    }
+  }
+
+  return currentCollection;
+}

--- a/content/watchFolder.mjs
+++ b/content/watchFolder.mjs
@@ -268,6 +268,10 @@ export class WatchFolderService {
         // Get relative path from watchPath to filePath
         if (filePath.startsWith(watchPath)) {
           let relativePath = filePath.substring(watchPath.length);
+          Zotero.debug(`[WatchFolder] File path: ${filePath}`);
+          Zotero.debug(`[WatchFolder] Watch path: ${watchPath}`);
+          Zotero.debug(`[WatchFolder] Initial relative path: ${relativePath}`);
+
           // Remove leading separator
           if (relativePath.startsWith('/') || relativePath.startsWith('\\')) {
             relativePath = relativePath.substring(1);
@@ -278,10 +282,14 @@ export class WatchFolderService {
           pathParts.pop(); // Remove filename
           
           if (pathParts.length > 0) {
+            Zotero.debug(`[WatchFolder] Folder parts found: ${JSON.stringify(pathParts)}`);
             targetCollection = targetCollection + '/' + pathParts.join('/');
+          } else {
+            Zotero.debug(`[WatchFolder] No subfolders found in relative path.`);
           }
         }
-
+        
+        Zotero.debug(`[WatchFolder] Final target collection path: ${targetCollection}`);
         newFiles.push({ path: filePath, collection: targetCollection });
       }
 

--- a/content/watchFolder.mjs
+++ b/content/watchFolder.mjs
@@ -5,7 +5,7 @@
  */
 
 import { getPref, delay, getFileHash } from './utils.mjs';
-import { scanFolder } from './fileScanner.mjs';
+import { scanFolder, scanFolderRecursive } from './fileScanner.mjs';
 import { importFile, handlePostImportAction } from './fileImporter.mjs';
 import { TrackingStore } from './trackingStore.mjs';
 import { renameAttachment } from './fileRenamer.mjs';
@@ -244,8 +244,8 @@ export class WatchFolderService {
         return;
       }
 
-      // Scan for files
-      const files = await scanFolder(watchPath);
+      // Scan for files recursively
+      const files = await scanFolderRecursive(watchPath);
 
       // Filter out already tracked and currently processing files
       const newFiles = [];
@@ -262,7 +262,27 @@ export class WatchFolderService {
           continue;
         }
 
-        newFiles.push(filePath);
+        // Calculate target collection based on relative path
+        let targetCollection = getPref('targetCollection') || 'Inbox';
+        
+        // Get relative path from watchPath to filePath
+        if (filePath.startsWith(watchPath)) {
+          let relativePath = filePath.substring(watchPath.length);
+          // Remove leading separator
+          if (relativePath.startsWith('/') || relativePath.startsWith('\\')) {
+            relativePath = relativePath.substring(1);
+          }
+          
+          // Get directory part of relative path
+          const pathParts = relativePath.split(/[/\\]/);
+          pathParts.pop(); // Remove filename
+          
+          if (pathParts.length > 0) {
+            targetCollection = targetCollection + '/' + pathParts.join('/');
+          }
+        }
+
+        newFiles.push({ path: filePath, collection: targetCollection });
       }
 
       if (newFiles.length > 0) {
@@ -273,8 +293,8 @@ export class WatchFolderService {
         this._currentInterval = (getPref('pollInterval') || 5) * 1000;
 
         // Process new files
-        for (const filePath of newFiles) {
-          await this._processNewFile(filePath);
+        for (const fileObj of newFiles) {
+          await this._processNewFile(fileObj.path, fileObj.collection);
         }
       } else {
         // Increment empty scan counter for adaptive polling
@@ -304,14 +324,15 @@ export class WatchFolderService {
    * Process a newly detected file
    * @private
    * @param {string} filePath - Absolute path to the file
+   * @param {string} [targetCollection] - Target collection path
    * @returns {Promise<void>}
    */
-  async _processNewFile(filePath) {
+  async _processNewFile(filePath, targetCollection) {
     // Mark as processing to prevent duplicate handling
     this._processingFiles.add(filePath);
 
     try {
-      Zotero.debug(`[WatchFolder] Processing new file: ${filePath}`);
+      Zotero.debug(`[WatchFolder] Processing new file: ${filePath} into ${targetCollection}`);
 
       // Step 1: Check if file is stable (size not changing)
       const isStable = await this._waitForFileStable(filePath);
@@ -373,7 +394,7 @@ export class WatchFolderService {
       }
 
       // Step 3: Import file via fileImporter
-      const item = await importFile(filePath);
+      const item = await importFile(filePath, { collectionName: targetCollection });
 
       if (!item || !item.id) {
         Zotero.debug(`[WatchFolder] Import failed for: ${filePath}`);

--- a/migrate-imported.sh
+++ b/migrate-imported.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Migrate scattered 'imported' subfolders into a single root-level imported/ folder.
+# Usage: ./migrate-imported.sh /path/to/watch/folder [--dry-run]
+#
+# Before: watch/subfolder/imported/file.pdf
+# After:  watch/imported/subfolder/file.pdf
+
+set -euo pipefail
+
+WATCH_ROOT="${1:-}"
+DRY_RUN=false
+[[ "${2:-}" == "--dry-run" ]] && DRY_RUN=true
+
+if [[ -z "$WATCH_ROOT" ]]; then
+    echo "Usage: $0 /path/to/watch/folder [--dry-run]"
+    exit 1
+fi
+
+if [[ ! -d "$WATCH_ROOT" ]]; then
+    echo "Error: '$WATCH_ROOT' is not a directory"
+    exit 1
+fi
+
+ROOT_IMPORTED="$WATCH_ROOT/imported"
+echo "Watch root:      $WATCH_ROOT"
+echo "Target imported: $ROOT_IMPORTED"
+$DRY_RUN && echo "(dry run — no files will be moved)"
+echo ""
+
+moved=0
+skipped=0
+
+# Find all 'imported' directories that are NOT the root-level one
+while IFS= read -r -d '' imported_dir; do
+    # Skip the root-level imported/ itself
+    if [[ "$imported_dir" == "$ROOT_IMPORTED" ]]; then
+        continue
+    fi
+
+    # Compute the path of imported_dir's parent relative to watch root
+    parent_dir="$(dirname "$imported_dir")"
+    rel_parent="${parent_dir#"$WATCH_ROOT"}"
+    rel_parent="${rel_parent#/}"  # strip leading slash
+
+    # Move each file inside this imported/ dir
+    while IFS= read -r -d '' src_file; do
+        # Path of the file relative to this imported/ dir
+        rel_file="${src_file#"$imported_dir/"}"
+
+        if [[ -z "$rel_parent" ]]; then
+            dest_file="$ROOT_IMPORTED/$rel_file"
+        else
+            dest_file="$ROOT_IMPORTED/$rel_parent/$rel_file"
+        fi
+
+        dest_dir="$(dirname "$dest_file")"
+
+        if $DRY_RUN; then
+            echo "  MOVE: $src_file"
+            echo "    ->  $dest_file"
+        else
+            mkdir -p "$dest_dir"
+            if [[ -e "$dest_file" ]]; then
+                echo "  SKIP (exists): $dest_file"
+                ((skipped++)) || true
+                continue
+            fi
+            mv "$src_file" "$dest_file"
+            echo "  Moved: $dest_file"
+        fi
+        ((moved++)) || true
+    done < <(find "$imported_dir" -type f -print0)
+
+    # Remove empty imported/ subdir after migration
+    if ! $DRY_RUN; then
+        find "$imported_dir" -type d -empty -delete 2>/dev/null || true
+    fi
+
+done < <(find "$WATCH_ROOT" -type d -name 'imported' -print0)
+
+echo ""
+if $DRY_RUN; then
+    echo "Dry run complete. $moved file(s) would be moved, $skipped skipped."
+else
+    echo "Done. $moved file(s) moved, $skipped skipped."
+fi

--- a/migrate-imported.sh
+++ b/migrate-imported.sh
@@ -65,8 +65,13 @@ while IFS= read -r -d '' imported_dir; do
                 ((skipped++)) || true
                 continue
             fi
-            mv "$src_file" "$dest_file"
-            echo "  Moved: $dest_file"
+            if mv "$src_file" "$dest_file" 2>/dev/null; then
+              echo "  Moved: $dest_file"
+            else
+              echo "  WARN (mv failed): $src_file"
+              ((skipped++)) || true
+              continue
+            fi
         fi
         ((moved++)) || true
     done < <(find "$imported_dir" -type f -print0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zotero-watch-folder",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zotero-watch-folder",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "GPL-3.0",
       "devDependencies": {
         "archiver": "^7.0.0",


### PR DESCRIPTION
This pull request adds support for recursively scanning subfolders in the watch folder and automatically mapping them to nested Zotero collections, significantly improving the organization of imported files. Now, when new files are detected in subfolders, the plugin will create corresponding nested collections within Zotero and import the files into the appropriate collection paths. The batch import and first-run import logic have also been updated to handle this new behavior.

**Recursive folder monitoring and collection mapping:**

* Added recursive scanning of subfolders using `scanFolderRecursive` in both the main watch loop and the first-run handler, ensuring all files in nested directories are detected and processed. [[1]](diffhunk://#diff-f03d515b7504c985936bdf065751117e0a81ab56bb1ced07d8ea7bee7919dfedL8-R8) [[2]](diffhunk://#diff-f03d515b7504c985936bdf065751117e0a81ab56bb1ced07d8ea7bee7919dfedL247-R248) [[3]](diffhunk://#diff-9fd4d3e9abfad2826a6c6451b70facbcdf3520854fd3d91fc803f771eb6f2480L9-R9) [[4]](diffhunk://#diff-9fd4d3e9abfad2826a6c6451b70facbcdf3520854fd3d91fc803f771eb6f2480L64-R64)
* Implemented logic to map subfolder structure to nested Zotero collections, so files in e.g. `WatchFolder/Research/AI` are imported into `TargetCollection/Research/AI`. This is achieved by extracting the relative path and constructing the collection path accordingly in both the watch service and first-run import. [[1]](diffhunk://#diff-f03d515b7504c985936bdf065751117e0a81ab56bb1ced07d8ea7bee7919dfedL265-R293) [[2]](diffhunk://#diff-f03d515b7504c985936bdf065751117e0a81ab56bb1ced07d8ea7bee7919dfedR335-R343) [[3]](diffhunk://#diff-f03d515b7504c985936bdf065751117e0a81ab56bb1ced07d8ea7bee7919dfedL376-R405) [[4]](diffhunk://#diff-9fd4d3e9abfad2826a6c6451b70facbcdf3520854fd3d91fc803f771eb6f2480L152-R171)

**Collection creation enhancements:**

* Added a new utility function `getOrCreateCollectionPath` to create or retrieve a path of nested collections, ensuring that the Zotero collection hierarchy matches the folder structure.
* Updated the file import logic to use the new collection path utility when a slash-separated collection name is provided, supporting both flat and nested collection imports. [[1]](diffhunk://#diff-853e3492e2663f43113322b8f0450879c77781c581093bfeeb7fac33c0966865L8-R15) [[2]](diffhunk://#diff-853e3492e2663f43113322b8f0450879c77781c581093bfeeb7fac33c0966865L35-R41)

**Batch import improvements:**

* Modified `importBatch` to accept an array of either file paths or objects specifying both the file path and its target collection, enabling batch imports that preserve folder-to-collection mapping. [[1]](diffhunk://#diff-853e3492e2663f43113322b8f0450879c77781c581093bfeeb7fac33c0966865L130-R142) [[2]](diffhunk://#diff-853e3492e2663f43113322b8f0450879c77781c581093bfeeb7fac33c0966865L150-R165)

**Documentation update:**

* Updated the `README.md` to document the new recursive subfolder import feature and corrected the repository URL. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R9) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L80-R81)