### PR TITLE
Multiple watch folders + two-way Mode 2 mirror (no delete)

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -35,6 +35,13 @@ async function startup({ id, version, resourceURI, rootURI }, reason) {
   // The pref-pane / wizard surfaces the opt-in switch to whole-library mode.
   _migrateScopeModeForExistingInstall();
 
+  // v2.9 migration: fold the existing single-folder config into a one-element
+  // `watchMappings` array (id "legacy"). MUST run AFTER the scopeMode migration
+  // above so the pinned scope is copied, not the raw default. Fail-closed: any
+  // error leaves watchMappings empty so the runtime keeps using the legacy
+  // scalars (never a half-built multi-mapping state on a delete-capable plugin).
+  _migrateToWatchMappings();
+
   // Load the esbuild bundle into the Zotero global scope.
   // rootURI already ends with "/", so do NOT add another slash.
   const ctx = { rootURI };
@@ -161,6 +168,17 @@ function _initDefaultPrefs() {
   // Performance
   _set("adaptivePolling",        true);
   _set("maxConcurrentMetadata",  2);
+
+  // v2.9 multi-mapping — watch MULTIPLE folders, each mapped to its own target
+  // (a collection or a whole/group library) with its own mode + storage. All
+  // five keys are gated by `watchMappingsMulti`: while it is false the runtime
+  // synthesizes a SINGLE mapping from the legacy scalars above, so behavior is
+  // byte-identical to the single-root plugin. See content/mappings.mjs.
+  _set("watchMappings",                 "[]");   // JSON: [{id, sourcePath, scopeMode, syncRootCollectionKey, syncRootLibraryID, mode, pdfStorageStrategy}]
+  _set("watchMappingsMulti",            false);  // feature gate; false = legacy single-root path is authoritative
+  _set("baselineCompletedByMapping",    "{}");   // JSON: { [id]: baselineKey }        — per-mapping replacement for baselineCompletedForRoot
+  _set("watchRootFingerprintByMapping", "{}");   // JSON: { [id]: {count, namesHash} } — per-mapping replacement for watchRootTopLevelFingerprint
+  _set("mode3AckByMapping",             "{}");   // JSON: { [id]: true }               — per-mapping replacement for mode3LibraryDeleteAcknowledged
 }
 
 // ---------------------------------------------------------------------------
@@ -212,5 +230,90 @@ function _migrateScopeModeForExistingInstall() {
     // strictly safer than an accidental whole-library escalation.
     try { user = user || Services.prefs.getBranch(PREFIX); user.setCharPref("scopeMode", "collection"); } catch (_e) { /* */ }
     try { Zotero.logError(`[WatchFolder] v2.7 scopeMode migration error — pinned to 'collection' (fail-safe): ${e}`); } catch (_e) { /* */ }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// v2.9 multi-mapping migration. Folds an existing single-folder install into a
+// one-element `watchMappings` array (id "legacy"), and seeds the per-mapping
+// state maps from the legacy scalars so an upgraded Mode-3 install does NOT
+// re-baseline or re-arm the whole-library-delete prompt. Idempotent (returns
+// once `watchMappings` has a user value) and FAIL-CLOSED (any error leaves
+// `watchMappings` empty → the runtime falls back to the legacy scalars via the
+// synthesized single mapping, i.e. today's exact behavior, never an escalated
+// one). The "legacy" id matches trackingStore's factory default so existing
+// …-tracking-v2.json records resolve to this mapping with no file rewrite.
+//
+// MUST run AFTER _migrateScopeModeForExistingInstall so the copied scopeMode is
+// the pinned value, not the raw new default.
+// ---------------------------------------------------------------------------
+function _migrateToWatchMappings() {
+  const PREFIX = "extensions.zotero.watchFolder.";
+  try {
+    const user = Services.prefs.getBranch(PREFIX);
+    // Already in the unified folder-list model → never resurrect the legacy
+    // single-root scalars. TWO independent signals, because they fail in
+    // different ways:
+    //   1. watchMappings has a user value (a configured, non-empty list).
+    //   2. watchMappingsMulti (the gate) is ON.
+    // Signal 2 is the durable one: when the user removes EVERY folder, the list
+    // is written as "[]" — which EQUALS the "[]" default, so Mozilla drops the
+    // user value from prefs.js on shutdown and signal 1 is false on the next
+    // launch. That used to re-fold the stale scalars into a phantom mapping
+    // (e.g. "no collection set / target missing"). The gate is a boolean whose
+    // user value `true` != the `false` default, so it persists across restart
+    // and correctly means "folder-list model active; empty list = watch nothing".
+    let gateOn = false;
+    try { gateOn = user.getBoolPref("watchMappingsMulti", false); } catch (_e) { gateOn = false; }
+    if (gateOn || user.prefHasUserValue("watchMappings")) {
+      try { user.setBoolPref("watchMappingsMulti", true); } catch (_e) { /* */ }
+      return;
+    }
+
+    // A configured install is signalled by a non-empty watch folder. A fresh
+    // install has none → leave watchMappings at its "[]" default (the setup
+    // wizard will append the first mapping).
+    const sourcePath = user.getCharPref("sourcePath", "") || "";
+    if (!sourcePath) return;
+
+    const mapping = {
+      id: "legacy",
+      sourcePath,
+      scopeMode: user.getCharPref("scopeMode", "library"),
+      syncRootCollectionKey: user.getCharPref("syncRootCollectionKey", "") || "",
+      syncRootLibraryID: user.getIntPref("syncRootLibraryID", 1),
+      mode: user.getCharPref("mode", "mode1"),
+      pdfStorageStrategy: user.getCharPref("pdfStorageStrategy", "stored"),
+    };
+    user.setCharPref("watchMappings", JSON.stringify([mapping]));
+
+    // Seed per-mapping state maps from the old scalars (blast-radius preserving).
+    const baselineDone = user.getCharPref("baselineCompletedForRoot", "") || "";
+    user.setCharPref("baselineCompletedByMapping",
+      JSON.stringify(baselineDone ? { legacy: baselineDone } : {}));
+
+    let fp = {};
+    try {
+      const raw = user.getCharPref("watchRootTopLevelFingerprint", "") || "";
+      if (raw) { const parsed = JSON.parse(raw); if (parsed && typeof parsed === "object") fp = { legacy: parsed }; }
+    } catch (_e) { fp = {}; }
+    user.setCharPref("watchRootFingerprintByMapping", JSON.stringify(fp));
+
+    let ack = false;
+    try { ack = user.getBoolPref("mode3LibraryDeleteAcknowledged", false); } catch (_e) { ack = false; }
+    user.setCharPref("mode3AckByMapping", JSON.stringify(ack ? { legacy: true } : {}));
+
+    // v2.10: one unified folder-list model — a configured single-root install
+    // becomes watchMappings[legacy] with the gate ON, so "1 folder" is just the
+    // list with N=1 (import-only, like every folder). This is the safe direction
+    // (import-only never deletes); Mode 2/3 are placeholders until per-mapping
+    // mirror/delete lands.
+    user.setBoolPref("watchMappingsMulti", true);
+    try { Zotero.debug(`[WatchFolder] v2.10 migration: folded single-folder config into watchMappings[legacy] + enabled the unified folder-list model (scope=${mapping.scopeMode}).`); } catch (_e) { /* */ }
+  } catch (e) {
+    // FAIL-CLOSED: leave watchMappings empty. getActiveMappings() then
+    // synthesizes a single mapping from the legacy scalars, so the plugin keeps
+    // doing exactly what it did before — never a partially-migrated state.
+    try { Zotero.logError(`[WatchFolder] v2.9 watchMappings migration error — left unmigrated (fail-safe): ${e}`); } catch (_e) { /* */ }
   }
 }

--- a/content/baseline.mjs
+++ b/content/baseline.mjs
@@ -59,6 +59,44 @@ async function _hashViaCache(absPath, statHint) {
 }
 
 const BASELINE_PREF = 'baselineCompletedForRoot';
+const BASELINE_MAP_PREF = 'baselineCompletedByMapping';
+/** Must equal mappings.mjs::LEGACY_MAPPING_ID. */
+const LEGACY_MAPPING_ID = 'legacy';
+
+/**
+ * Read the baseline-done key for a mapping. The legacy/synthesized mapping
+ * (id 'legacy' or no id) uses the flat scalar pref `baselineCompletedForRoot`
+ * — byte-identical to the single-root plugin and still what itemMembershipHandler
+ * reads. Real mapping ids use a per-id slot in the `baselineCompletedByMapping`
+ * JSON so two mappings targeting the SAME collection never share/clobber state.
+ * @param {string|undefined} mappingId
+ * @returns {string}
+ */
+function _getBaselineDone(mappingId) {
+  if (mappingId && mappingId !== LEGACY_MAPPING_ID) {
+    try {
+      const m = JSON.parse(getPref(BASELINE_MAP_PREF) || '{}');
+      return (m && typeof m === 'object' && m[mappingId]) ? m[mappingId] : '';
+    } catch (_e) { return ''; }
+  }
+  return getPref(BASELINE_PREF) || '';
+}
+
+/**
+ * Persist the baseline-done key for a mapping (see {@link _getBaselineDone}).
+ * @param {string|undefined} mappingId
+ * @param {string} key
+ */
+function _setBaselineDone(mappingId, key) {
+  if (mappingId && mappingId !== LEGACY_MAPPING_ID) {
+    let m = {};
+    try { const parsed = JSON.parse(getPref(BASELINE_MAP_PREF) || '{}'); if (parsed && typeof parsed === 'object') m = parsed; } catch (_e) { m = {}; }
+    m[mappingId] = key || '';
+    setPref(BASELINE_MAP_PREF, JSON.stringify(m));
+    return;
+  }
+  setPref(BASELINE_PREF, key || '');
+}
 
 /**
  * The idempotency key the baseline is marked complete against. In collection
@@ -89,18 +127,24 @@ export function baselineKeyFor(syncRoot) {
  * Has the baseline been run for the current sync root?
  * @returns {Promise<boolean>}
  */
-export async function isBaselineNeeded() {
+export async function isBaselineNeeded(ctx) {
   let syncRoot;
-  try { syncRoot = await resolveSyncRoot(); }
+  try { syncRoot = await resolveSyncRoot(ctx); }
   catch (_e) { return false; }
   if (!syncRoot) return false;
-  const completed = getPref(BASELINE_PREF);
+  const completed = _getBaselineDone(ctx && ctx.id);
   return completed !== _baselineKey(syncRoot);
 }
 
-/** Mark the baseline complete for `syncRootKey`. */
-export function markBaselineComplete(syncRootKey) {
-  setPref(BASELINE_PREF, syncRootKey || '');
+/**
+ * Mark the baseline complete for `syncRootKey`. When `mappingId` is a real
+ * (non-legacy) mapping id the completion is stored per-mapping; otherwise it
+ * writes the legacy scalar.
+ * @param {string} syncRootKey
+ * @param {string} [mappingId]
+ */
+export function markBaselineComplete(syncRootKey, mappingId) {
+  _setBaselineDone(mappingId, syncRootKey || '');
 }
 
 /**
@@ -117,18 +161,20 @@ export function markBaselineComplete(syncRootKey) {
  * @returns {Promise<Object>} summary { ok, baselineRan, copies, mkdirs, errors, skipped? }
  */
 export async function runBaseline(opts = {}) {
-  const watchRoot = opts.watchRoot ?? getPref('sourcePath');
+  const ctx = opts.mapping;
+  const mappingId = ctx && ctx.id ? ctx.id : undefined;
+  const watchRoot = opts.watchRoot ?? (ctx && ctx.sourcePath) ?? getPref('sourcePath');
   if (!watchRoot) return { ok: false, baselineRan: false, skipped: 'no-watch-root' };
 
   let syncRoot = opts.syncRoot;
   if (typeof syncRoot === 'undefined') {
-    try { syncRoot = await resolveSyncRoot(); }
+    try { syncRoot = await resolveSyncRoot(ctx); }
     catch (e) { return { ok: false, baselineRan: false, skipped: 'sync-root-error', error: String(e?.message ?? e) }; }
   }
   if (!syncRoot) return { ok: false, baselineRan: false, skipped: 'no-sync-root' };
 
   const baselineKey = _baselineKey(syncRoot);
-  const completed = getPref(BASELINE_PREF);
+  const completed = _getBaselineDone(mappingId);
   if (!opts.force && completed === baselineKey) {
     return { ok: true, baselineRan: false, skipped: 'already-completed' };
   }
@@ -155,7 +201,7 @@ export async function runBaseline(opts = {}) {
 
     // ─── B.6 — empty subcollections → empty disk folders ────────────
     for (const col of collections) {
-      const relPath = await collectionKeyToDiskRelativePath(col.key);
+      const relPath = await collectionKeyToDiskRelativePath(col.key, ctx);
       if (relPath == null || relPath === '') continue;
       const absPath = _toAbs(watchRoot, relPath);
       try {
@@ -164,6 +210,7 @@ export async function runBaseline(opts = {}) {
           if (!dryRun) {
             await IOUtils.makeDirectory(absPath, { ignoreExisting: true, createAncestors: true });
             store.add(createCollectionRecord({
+              mappingId,
               localPath: relPath,
               zoteroCollectionKey: col.key,
               parentCollectionKey: _parentKeyOf(col),
@@ -176,6 +223,7 @@ export async function runBaseline(opts = {}) {
           // adopt the tracking record so later events route correctly.
           if (!dryRun) {
             store.add(createCollectionRecord({
+              mappingId,
               localPath: relPath,
               zoteroCollectionKey: col.key,
               parentCollectionKey: _parentKeyOf(col),
@@ -201,7 +249,7 @@ export async function runBaseline(opts = {}) {
       const { attachment, item } = entry;
       try {
         const result = await _copyAttachmentToCanonical({
-          attachment, item, syncRoot, watchRoot, store, dryRun, diskHashIndex,
+          attachment, item, syncRoot, watchRoot, store, dryRun, diskHashIndex, ctx,
         });
         if (result === 'copied') copies++;
         else if (result === 'adopted-different-path') reconciles++;
@@ -219,7 +267,7 @@ export async function runBaseline(opts = {}) {
 
     if (!dryRun) {
       try { await store.save(); } catch (_e) { /* logged inside save */ }
-      markBaselineComplete(baselineKey);
+      markBaselineComplete(baselineKey, mappingId);
     }
 
     Zotero.debug(`[WatchFolder] baseline: complete (copies=${copies} mkdirs=${mkdirs} reconciles=${reconciles} errors=${errors})`);
@@ -271,10 +319,11 @@ export async function copyAttachmentToCanonical(args) {
  * @param {boolean} [args.dryRun=false]
  * @returns {Promise<{ok: boolean, copies: number, mkdirs: number, errors: number}>}
  */
-export async function adoptCollectionSubtree({ rootCollection, syncRoot, watchRoot, store, dryRun = false, diskHashIndex }) {
+export async function adoptCollectionSubtree({ rootCollection, syncRoot, watchRoot, store, dryRun = false, diskHashIndex, ctx }) {
   if (!rootCollection || !syncRoot || !watchRoot || !store) {
     return { ok: false, copies: 0, mkdirs: 0, errors: 0, reason: 'invalid-args' };
   }
+  const mappingId = ctx && ctx.id ? ctx.id : undefined;
   let copies = 0, mkdirs = 0, errors = 0, reconciles = 0;
   try {
     const { collections, attachments } = await _enumerateFrom(rootCollection, syncRoot);
@@ -286,7 +335,7 @@ export async function adoptCollectionSubtree({ rootCollection, syncRoot, watchRo
       ? diskHashIndex
       : (dryRun ? null : await _buildDiskHashIndex(watchRoot));
     for (const col of collections) {
-      const relPath = await collectionKeyToDiskRelativePath(col.key);
+      const relPath = await collectionKeyToDiskRelativePath(col.key, ctx);
       if (relPath == null || relPath === '') continue;
       const absPath = _toAbs(watchRoot, relPath);
       try {
@@ -295,6 +344,7 @@ export async function adoptCollectionSubtree({ rootCollection, syncRoot, watchRo
           if (!dryRun) {
             await IOUtils.makeDirectory(absPath, { ignoreExisting: true, createAncestors: true });
             store.add(createCollectionRecord({
+              mappingId,
               localPath: relPath,
               zoteroCollectionKey: col.key,
               parentCollectionKey: _parentKeyOf(col),
@@ -304,6 +354,7 @@ export async function adoptCollectionSubtree({ rootCollection, syncRoot, watchRo
           mkdirs++;
         } else if (!store.getCollectionRecord(col.key) && !dryRun) {
           store.add(createCollectionRecord({
+            mappingId,
             localPath: relPath,
             zoteroCollectionKey: col.key,
             parentCollectionKey: _parentKeyOf(col),
@@ -325,7 +376,7 @@ export async function adoptCollectionSubtree({ rootCollection, syncRoot, watchRo
     for (const { attachment, item } of attachments) {
       try {
         const result = await _copyAttachmentToCanonical({
-          attachment, item, syncRoot, watchRoot, store, dryRun, diskHashIndex: index,
+          attachment, item, syncRoot, watchRoot, store, dryRun, diskHashIndex: index, ctx,
         });
         if (result === 'copied') copies++;
         else if (result === 'adopted-different-path') reconciles++;
@@ -357,18 +408,19 @@ export async function adoptCollectionSubtree({ rootCollection, syncRoot, watchRo
  *   'skipped'                 — destination existed (adopted) or nothing to do
  * Throws on hard IO failures.
  */
-async function _copyAttachmentToCanonical({ attachment, item, syncRoot, watchRoot, store, dryRun, diskHashIndex }) {
+async function _copyAttachmentToCanonical({ attachment, item, syncRoot, watchRoot, store, dryRun, diskHashIndex, ctx }) {
+  const mappingId = ctx && ctx.id ? ctx.id : undefined;
   const filename = attachment.attachmentFilename;
   if (!filename) return 'skipped';
 
-  const canonical = await chooseCanonicalCollection(item, syncRoot.collection);
+  const canonical = await chooseCanonicalCollection(item, syncRoot.collection, {}, ctx);
   if (!canonical) return 'skipped';
   // Library scope: an Unfiled item (UNFILED sentinel) mirrors to the watch-
   // folder root (relDir = '', canonicalCollectionKey = null). Otherwise it's
   // a real collection — resolve its disk-relative folder path.
   const isUnfiled = canonical === UNFILED;
   const canonicalCollectionKey = isUnfiled ? null : canonical.key;
-  const relDir = isUnfiled ? '' : await collectionKeyToDiskRelativePath(canonical.key);
+  const relDir = isUnfiled ? '' : await collectionKeyToDiskRelativePath(canonical.key, ctx);
   if (relDir == null) return 'skipped';
   const relPath = relDir === '' ? filename : `${relDir}/${filename}`;
   const absDest = _toAbs(watchRoot, relPath);
@@ -379,7 +431,7 @@ async function _copyAttachmentToCanonical({ attachment, item, syncRoot, watchRoo
   const destExists = await IOUtils.exists(absDest);
   if (destExists) {
     if (!store.getByAttachmentKey(attachment.key) && !dryRun) {
-      await _adoptExistingDestFile({ attachment, item, canonicalCollectionKey, relPath, absDest, store });
+      await _adoptExistingDestFile({ attachment, item, canonicalCollectionKey, relPath, absDest, store, mappingId });
     }
     return 'skipped';
   }
@@ -405,6 +457,7 @@ async function _copyAttachmentToCanonical({ attachment, item, syncRoot, watchRoo
         try { stat = await IOUtils.stat(matchAbs); } catch (_e) { /* best effort */ }
         const attHash = await _attachmentContentHashCached(attachment);
         store.add(createFileRecord({
+          mappingId,
           localPath: matchRel,
           canonicalLocalPath: matchRel,
           lastSyncedHash: attHash,
@@ -461,6 +514,7 @@ async function _copyAttachmentToCanonical({ attachment, item, syncRoot, watchRoo
     const hash = await _hashViaCache(absDest, stat);
 
     store.add(createFileRecord({
+      mappingId,
       localPath: relPath,
       canonicalLocalPath: relPath,
       lastSyncedHash: hash,
@@ -476,11 +530,12 @@ async function _copyAttachmentToCanonical({ attachment, item, syncRoot, watchRoo
   return 'copied';
 }
 
-async function _adoptExistingDestFile({ attachment, item, canonicalCollectionKey, relPath, absDest, store }) {
+async function _adoptExistingDestFile({ attachment, item, canonicalCollectionKey, relPath, absDest, store, mappingId }) {
   let stat = null;
   try { stat = await IOUtils.stat(absDest); } catch (_e) { /* best effort */ }
   const hash = await _hashViaCache(absDest, stat);
   store.add(createFileRecord({
+    mappingId,
     localPath: relPath,
     canonicalLocalPath: relPath,
     lastSyncedHash: hash,

--- a/content/canonicalPath.mjs
+++ b/content/canonicalPath.mjs
@@ -75,7 +75,10 @@ export const UNFILED = Object.freeze({ isUnfiled: true });
  *
  * @returns {'library'|'collection'}
  */
-export function getScopeMode() {
+export function getScopeMode(ctx) {
+  if (ctx && (ctx.scopeMode === 'library' || ctx.scopeMode === 'collection')) {
+    return ctx.scopeMode;
+  }
   return getPref('scopeMode') === 'library' ? 'library' : 'collection';
 }
 
@@ -204,7 +207,7 @@ export function invalidateCanonicalPathCache() {
  * @throws {SyncRootMissingError} if a key is configured but the collection
  *   cannot be resolved (deleted, wrong library, etc).
  */
-export async function resolveSyncRoot() {
+export async function resolveSyncRoot(ctx) {
   // ── scopeMode === 'library' — the whole-library anchor (2.7.0) ──
   // Return a library-root descriptor instead of a chosen collection.
   // `collection: null` + `isLibraryRoot: true`; callers branch on the flag
@@ -212,8 +215,8 @@ export async function resolveSyncRoot() {
   // the only input is the library id. A missing library (stale group id)
   // throws LibraryUnavailableError (a SyncRootMissingError subclass) so the
   // existing catch→pause contract still applies.
-  if (getScopeMode() === 'library') {
-    const libraryID = getPref('syncRootLibraryID') || Zotero.Libraries.userLibraryID;
+  if (getScopeMode(ctx) === 'library') {
+    const libraryID = (ctx ? ctx.syncRootLibraryID : getPref('syncRootLibraryID')) || Zotero.Libraries.userLibraryID;
     try {
       const lib = Zotero.Libraries.get ? Zotero.Libraries.get(libraryID) : true;
       if (!lib) {
@@ -227,9 +230,9 @@ export async function resolveSyncRoot() {
   }
 
   // ── scopeMode === 'collection' — legacy single-sync-root (unchanged) ──
-  const key = getPref('syncRootCollectionKey');
+  const key = ctx ? ctx.syncRootCollectionKey : getPref('syncRootCollectionKey');
   if (!key) return null;
-  const libraryID = getPref('syncRootLibraryID') || Zotero.Libraries.userLibraryID;
+  const libraryID = (ctx ? ctx.syncRootLibraryID : getPref('syncRootLibraryID')) || Zotero.Libraries.userLibraryID;
   const collection = await Zotero.Collections.getByLibraryAndKeyAsync(libraryID, key);
   if (!collection) {
     throw new SyncRootMissingError(
@@ -264,8 +267,8 @@ export async function resolveSyncRoot() {
  *   - `"Methods/Subtopic"` for nested collections under the sync root.
  *   - `null` if the collection isn't under the sync root, or sync root unset.
  */
-export async function collectionKeyToRelativePath(collectionKey) {
-  const syncRoot = await resolveSyncRoot();
+export async function collectionKeyToRelativePath(collectionKey, ctx) {
+  const syncRoot = await resolveSyncRoot(ctx);
   if (!syncRoot) return null;
   const libraryID = syncRoot.libraryID;
   const target = await Zotero.Collections.getByLibraryAndKeyAsync(libraryID, collectionKey);
@@ -338,8 +341,8 @@ export async function collectionKeyToRelativePath(collectionKey) {
  * @param {string} collectionKey
  * @returns {Promise<string|null>}
  */
-export async function collectionKeyToDiskRelativePath(collectionKey) {
-  const rel = await collectionKeyToRelativePath(collectionKey);
+export async function collectionKeyToDiskRelativePath(collectionKey, ctx) {
+  const rel = await collectionKeyToRelativePath(collectionKey, ctx);
   if (rel === '' || rel == null) return rel;
   return rel.split('/').map(sanitizeCollectionNameSegment).join('/');
 }
@@ -368,22 +371,26 @@ export async function collectionKeyToDiskRelativePath(collectionKey) {
  *   resolved via `resolveSyncRoot`.
  * @returns {Promise<string|null>}
  */
-export async function collectionKeyToRelativePathCached(collectionKey, libraryID) {
+export async function collectionKeyToRelativePathCached(collectionKey, libraryID, ctx) {
   // If the caller didn't pre-resolve libraryID, fall back to the sync
   // root's library. Doing this lookup once up front means cached hits
   // (the common case) skip an extra resolveSyncRoot call on subsequent
   // requests for the same key.
   let lib = libraryID;
   if (lib == null) {
-    const syncRoot = await resolveSyncRoot();
+    const syncRoot = await resolveSyncRoot(ctx);
     if (!syncRoot) return null;
     lib = syncRoot.libraryID;
   }
-  const cacheKey = `${lib}:${collectionKey}`;
+  // Mapping-aware cache key: two mappings in the SAME library (e.g. one
+  // library-scope, one collection-scope) resolve the same collectionKey to
+  // DIFFERENT relative paths, so the mapping id must partition the cache or a
+  // hit from mapping A would be served to mapping B (scope-boundary bleed).
+  const cacheKey = `${ctx && ctx.id ? ctx.id : '_'}:${lib}:${collectionKey}`;
   if (_relativePathCache.has(cacheKey)) {
     return _relativePathCache.get(cacheKey);
   }
-  const result = await collectionKeyToRelativePath(collectionKey);
+  const result = await collectionKeyToRelativePath(collectionKey, ctx);
   if (result !== null) {
     _relativePathCache.set(cacheKey, result);
   }
@@ -406,8 +413,8 @@ export async function collectionKeyToRelativePathCached(collectionKey, libraryID
  *   is returned for an empty path.
  * @throws {SyncRootMissingError} via `resolveSyncRoot`.
  */
-export async function relativePathToCollection(relativePathStr, { createIfMissing = false } = {}) {
-  const syncRoot = await resolveSyncRoot();
+export async function relativePathToCollection(relativePathStr, { createIfMissing = false } = {}, ctx) {
+  const syncRoot = await resolveSyncRoot(ctx);
   if (!syncRoot) return null;
 
   // ── Library mode: '' → UNFILED; first segment → a TOP-LEVEL collection ──
@@ -563,14 +570,14 @@ export function isSpecialCollection(collection) {
  * @param {{existingTrackingRecord?: object, userPreferredKey?: string}} [opts]
  * @returns {Promise<object|null>} The chosen Zotero.Collection, or null.
  */
-export async function chooseCanonicalCollection(item, syncRootCollection, opts = {}) {
+export async function chooseCanonicalCollection(item, syncRootCollection, opts = {}, ctx) {
   if (!item) return null;
 
   // ── Library mode: syncRootCollection is null (the whole library is the root).
   // An item in no qualifying real collection is Unfiled → return the UNFILED
   // sentinel (distinct from null = "skip"). Otherwise the priority rules below
   // run identically, scoped library-wide via collectionKeyToRelativePath. ──
-  const libraryMode = getScopeMode() === 'library';
+  const libraryMode = getScopeMode(ctx) === 'library';
   if (libraryMode) {
     const ids = (typeof item.getCollections === 'function') ? item.getCollections() : [];
     if (!ids || ids.length === 0) return UNFILED;
@@ -579,7 +586,7 @@ export async function chooseCanonicalCollection(item, syncRootCollection, opts =
       const c = Zotero.Collections.get(id);
       if (!c) continue;
       if (isSpecialCollection(c)) continue;
-      const relPath = await collectionKeyToRelativePath(c.key);
+      const relPath = await collectionKeyToRelativePath(c.key, ctx);
       if (relPath === null) continue; // special/unsafe segment in chain
       cand.push({ collection: c, relPath });
     }
@@ -599,7 +606,7 @@ export async function chooseCanonicalCollection(item, syncRootCollection, opts =
     const c = Zotero.Collections.get(id);
     if (!c) continue;
     if (isSpecialCollection(c)) continue;
-    const relPath = await collectionKeyToRelativePath(c.key);
+    const relPath = await collectionKeyToRelativePath(c.key, ctx);
     if (relPath === null) continue; // not under sync root
     candidates.push({ collection: c, relPath });
   }

--- a/content/collectionWatcher.mjs
+++ b/content/collectionWatcher.mjs
@@ -40,6 +40,8 @@ import * as mirrorExecutor from './mirrorExecutor.mjs';
 import { handleCollectionItemEvent } from './itemMembershipHandler.mjs';
 import * as baseline from './baseline.mjs';
 import { getPref } from './utils.mjs';
+import { isMultiMappingActive, getMappingById } from './mappings.mjs';
+import { mappingForCollection } from './mappingRouter.mjs';
 
 /**
  * @typedef {Object} MirrorAction
@@ -270,7 +272,26 @@ async function _processBatch(batch) {
   }
 }
 
+/**
+ * Owning-mapping context for a collection event.
+ *
+ * Multi-mapping (real installs): return the mapping that owns this collection
+ * via the nearest-ancestor rule, or `null` when no watch folder covers it.
+ * Legacy single-root (multi off — exercised only by the pre-folder-list tests):
+ * return `null`, which routes every ctx-consumer through the global scalar
+ * prefs, exactly as before. The caller distinguishes "legacy null" from
+ * "multi no-owner" via `isMultiMappingActive()`.
+ *
+ * @param {object} collection
+ * @returns {import('./mappings.mjs').MappingContext|null}
+ */
+function _ownerCtx(collection) {
+  if (!isMultiMappingActive()) return null;
+  return mappingForCollection(collection);
+}
+
 async function _dispatchCollection(event, ids, extraData) {
+  const multi = isMultiMappingActive();
   for (const id of ids) {
     try {
       if (event === 'delete' || event === 'trash') {
@@ -281,17 +302,22 @@ async function _dispatchCollection(event, ids, extraData) {
       if (!collection) continue;
       if (isSpecialCollection(collection)) continue;
 
+      // Multi-mapping: attribute the event to its owning watch folder; skip if
+      // none watches it. Legacy single-root uses global scope resolution (ctx null).
+      const ctx = _ownerCtx(collection);
+      if (multi && !ctx) continue;
+
       // Disk-domain variant: sanitizes each segment (FS-1) so the emitted
       // createFolder/moveFolder paths — and the localPath stored from them —
       // match the sanitized folders baseline creates and round-trip on
       // Windows-reserved/illegal collection names. Passes '' / null through.
-      const relPath = await collectionKeyToDiskRelativePath(collection.key);
+      const relPath = await collectionKeyToDiskRelativePath(collection.key, ctx);
       if (relPath === null) continue; // not under sync root
 
       if (event === 'add') {
-        await _handleAdd(collection, relPath);
+        await _handleAdd(collection, relPath, ctx);
       } else if (event === 'modify') {
-        await _handleModify(collection, relPath);
+        await _handleModify(collection, relPath, ctx);
       }
     } catch (e) {
       Zotero.logError(`[WatchFolder] collectionWatcher dispatch ${event}/${id}: ${e?.message ?? e}`);
@@ -299,7 +325,7 @@ async function _dispatchCollection(event, ids, extraData) {
   }
 }
 
-async function _handleAdd(collection, relPath) {
+async function _handleAdd(collection, relPath, ctx) {
   // Empty relPath means the sync root itself was "added" — that would only
   // fire if the user just created the sync-root collection during this
   // session (i.e., the prefs picker just made it). Nothing to mkdir for the
@@ -310,7 +336,7 @@ async function _handleAdd(collection, relPath) {
   // adopt-into-scope baseline so existing attachments get copied to disk
   // — not just an empty mkdir (review finding A4).
   if (_collectionHasContent(collection)) {
-    await _adoptIntoScope(collection);
+    await _adoptIntoScope(collection, ctx);
     return;
   }
   await _emit({
@@ -320,6 +346,7 @@ async function _handleAdd(collection, relPath) {
       parentCollectionKey: _parentKeyOf(collection),
       relativePath: relPath,
       name: collection.name,
+      mappingId: ctx ? ctx.id : undefined,
     },
   });
 }
@@ -337,7 +364,7 @@ function _collectionHasContent(collection) {
   } catch (_e) { return false; }
 }
 
-async function _handleModify(collection, currentRelPath) {
+async function _handleModify(collection, currentRelPath, ctx) {
   // A modify event covers any of: rename, reparent, description change,
   // sort-key change, etc. We only care if the rendered relative path
   // changed. If it did, emit a single moveFolder action; the executor
@@ -351,7 +378,7 @@ async function _handleModify(collection, currentRelPath) {
     // mkdir the folders + copy any existing attachment files so the
     // local view matches Zotero (review finding A4).
     if (currentRelPath === '') return;
-    await _adoptIntoScope(collection);
+    await _adoptIntoScope(collection, ctx);
     return;
   }
   if (record.localPath === currentRelPath) return; // no-op modify
@@ -364,6 +391,7 @@ async function _handleModify(collection, currentRelPath) {
       newRelativePath: currentRelPath,
       newName: collection.name,
       newParentCollectionKey: _parentKeyOf(collection),
+      mappingId: ctx ? ctx.id : undefined,
     },
   });
 }
@@ -375,6 +403,14 @@ async function _handleDelete(id, extraData) {
   if (!key || !_store) return;
   const record = _store.getCollectionRecord(key);
   if (!record) return; // never tracked → not under sync root → ignore
+  // Multi-mapping: the tracking record carries the owning mapping id (the
+  // collection is gone, so we can't walk ancestors). Resolve it; skip if the
+  // owner no longer exists. Legacy single-root: ctx null → global fallback.
+  let ctx = null;
+  if (isMultiMappingActive()) {
+    ctx = record.mappingId ? getMappingById(record.mappingId) : null;
+    if (!ctx) return;
+  }
   // Zotero-side deletion → trash the LOCAL folder (zoteroCollectionDeleted).
   // Distinct from localFolderDeleted (disk-side), which propagates to Zotero.
   await _emit({
@@ -382,6 +418,7 @@ async function _handleDelete(id, extraData) {
     payload: {
       collectionKey: key,
       oldRelativePath: record.localPath,
+      mappingId: ctx ? ctx.id : undefined,
     },
   });
 }
@@ -393,16 +430,16 @@ async function _handleDelete(id, extraData) {
  * `baseline.adoptCollectionSubtree` so behavior matches the install-
  * time B.2 + B.6 path.
  */
-async function _adoptIntoScope(collection) {
+async function _adoptIntoScope(collection, ctx) {
   if (!_store) return;
   let syncRoot;
-  try { syncRoot = await resolveSyncRoot(); }
+  try { syncRoot = await resolveSyncRoot(ctx); }
   catch (e) {
     Zotero.logError(`[WatchFolder] collectionWatcher adopt: ${e?.message ?? e}`);
     return;
   }
   if (!syncRoot) return;
-  const watchRoot = getPref('sourcePath');
+  const watchRoot = (ctx && ctx.sourcePath) || getPref('sourcePath');
   if (!watchRoot) return;
   try {
     const result = await baseline.adoptCollectionSubtree({
@@ -410,6 +447,7 @@ async function _adoptIntoScope(collection) {
       syncRoot,
       watchRoot,
       store: _store,
+      ctx: ctx || undefined,
     });
     Zotero.debug(`[WatchFolder] collectionWatcher: adopted ${collection.key} into scope (copies=${result.copies} mkdirs=${result.mkdirs} errors=${result.errors})`);
   } catch (e) {

--- a/content/fileScanner.mjs
+++ b/content/fileScanner.mjs
@@ -254,6 +254,142 @@ export async function scanFolderRecursive(folderPath, maxDepth = 10, _rootPath =
 }
 
 /**
+ * Cached, incremental tree walk (the "Option 1" scan optimization).
+ *
+ * Produces the SAME complete view as {@link scanFolderRecursive} — every
+ * allowed file under `rootPath`, with symlinks and reserved dirs skipped —
+ * PLUS the set of every subdirectory (absolute paths, matching
+ * `watchFolder._listSubdirectories` semantics), in ONE walk. The win: it
+ * skips the expensive `getChildren()` + per-file `stat()` for any directory
+ * whose mtime is unchanged since the previous walk.
+ *
+ * Why mtime is the right signal: a directory's mtime bumps on any DIRECT
+ * child add / remove / rename, so every STRUCTURAL change (a new file, a
+ * deleted file, a rename) forces that directory to be re-enumerated — which
+ * is exactly what import detection AND external-deletion detection rely on.
+ * The returned `files` are therefore always the COMPLETE current on-disk set
+ * (fresh entries for changed dirs + cached entries for unchanged ones), so
+ * deletion detection stays correct. Pure in-place CONTENT edits do NOT bump a
+ * dir's mtime and are intentionally not re-observed here: path-based tracking
+ * skips already-imported files, and the delete-safety gates re-hash the file
+ * DIRECTLY (they never trust scan metadata), so a stale cached size/mtime for
+ * an edited-in-place file is harmless.
+ *
+ * The walk still descends into EVERY directory (one `stat()` per dir to read
+ * its mtime), so a change nested below an unchanged parent is still detected —
+ * only the per-file work of unchanged dirs is elided.
+ *
+ * Fail-safe under unreliable filesystems: if a cloud client ever fails to bump
+ * a dir mtime on a change, a stale cache entry can only cause an UNDER-report
+ * (a new file seen late / a deletion not seen) — never a spurious deletion.
+ * Callers MUST still run a periodic FULL SWEEP (clear the cache map, then call
+ * again) as the backstop that bounds that latency.
+ *
+ * The classification of each child (symlink skip, reserved-dir skip, allowed
+ * file type, result shape) MUST stay in lock-step with {@link scanFolderRecursive}.
+ *
+ * @param {string} rootPath - Top-level watch root to walk.
+ * @param {Map<string, {mtime: number, files: Array, subdirs: string[]}>|null} [cache]
+ *   Per-watch-root cache keyed by absolute directory path. Pass `null` to force
+ *   a full, uncached walk (identical output to `scanFolderRecursive` + dirs).
+ *   Clearing the map before a call forces a full sweep.
+ * @param {number} [maxDepth=10] - Max recursion depth (matches scanFolderRecursive).
+ * @returns {Promise<{files: Array<{path: string, mtime: number, size: number, isSymlink: boolean, relativePath: string}>, dirs: string[]}>}
+ */
+export async function scanTree(rootPath, cache = null, maxDepth = 10) {
+    const files = [];
+    const dirs = [];
+    await _walkTreeCached(rootPath, rootPath, maxDepth, cache, files, dirs);
+    return { files, dirs };
+}
+
+/**
+ * Recursive worker for {@link scanTree}. Accumulates into `filesOut`/`dirsOut`.
+ * @private
+ */
+async function _walkTreeCached(dirPath, rootPath, maxDepth, cache, filesOut, dirsOut) {
+    if (!dirPath || maxDepth < 0) return;
+
+    let dirInfo;
+    try {
+        const exists = await IOUtils.exists(dirPath);
+        if (!exists) {
+            // Vanished dir: forget any stale snapshot so recovery is a clean walk.
+            if (cache) cache.delete(dirPath);
+            return;
+        }
+        dirInfo = await IOUtils.stat(dirPath);
+        if (dirInfo.type !== 'directory') {
+            if (cache) cache.delete(dirPath);
+            return;
+        }
+    } catch (e) {
+        Zotero.debug(`[Watch Folder] scanTree: stat failed for ${dirPath}: ${e && e.message ? e.message : e}`);
+        return;
+    }
+
+    const cached = cache ? cache.get(dirPath) : null;
+    let entryFiles;
+    let entrySubdirs;
+
+    if (cached && cached.mtime === dirInfo.lastModified) {
+        // Unchanged directory — reuse the last enumeration verbatim. Its direct
+        // children (names) cannot have changed since the mtime is identical, so
+        // there is nothing new to stat here.
+        entryFiles = cached.files;
+        entrySubdirs = cached.subdirs;
+    } else {
+        // New or structurally-changed directory — re-enumerate its children.
+        // NOTE: keep this classification in sync with scanFolderRecursive.
+        entryFiles = [];
+        entrySubdirs = [];
+        let children;
+        try {
+            children = await IOUtils.getChildren(dirPath);
+        } catch (e) {
+            Zotero.debug(`[Watch Folder] scanTree: getChildren failed for ${dirPath}: ${e && e.message ? e.message : e}`);
+            children = [];
+        }
+        for (const childPath of children) {
+            try {
+                // Never follow symlinks (see scanFolderRecursive: a symlink could
+                // redirect the walk outside the watch root).
+                if (_isSymlink(childPath)) {
+                    continue;
+                }
+                const info = await IOUtils.stat(childPath);
+                if (info.type === 'directory') {
+                    const dirName = PathUtils.filename(childPath);
+                    if (SKIP_DIRNAMES.has(dirName)) {
+                        continue;
+                    }
+                    entrySubdirs.push(childPath);
+                } else if (isAllowedFileType(childPath)) {
+                    entryFiles.push({
+                        path: childPath,
+                        mtime: info.lastModified,
+                        size: info.size,
+                        isSymlink: false,
+                        relativePath: _relPath(childPath, rootPath) ?? '',
+                    });
+                }
+            } catch (fileError) {
+                Zotero.debug(`[Watch Folder] scanTree: Error reading ${childPath}: ${fileError && fileError.message ? fileError.message : fileError}`);
+            }
+        }
+        if (cache) {
+            cache.set(dirPath, { mtime: dirInfo.lastModified, files: entryFiles, subdirs: entrySubdirs });
+        }
+    }
+
+    for (const f of entryFiles) filesOut.push(f);
+    for (const sub of entrySubdirs) {
+        dirsOut.push(sub);
+        await _walkTreeCached(sub, rootPath, maxDepth - 1, cache, filesOut, dirsOut);
+    }
+}
+
+/**
  * Check if a file is stable (not being written to)
  * Checks size twice with 1 second delay
  * @param {string} filePath - File to check

--- a/content/folderEventDetector.mjs
+++ b/content/folderEventDetector.mjs
@@ -46,8 +46,13 @@ import {
  *   the watch root (already enumerated by the caller — see
  *   `watchFolder._listSubdirectories`).
  * @param {string} ctx.watchRoot - Absolute watch-folder root.
+ * @param {string} [ctx.mappingId] - Owning mapping id (multi-folder model).
+ *   When set, only THIS mapping's collection records participate, and emitted
+ *   actions are stamped with it so the executor resolves the right watch root.
+ * @param {import('./mappings.mjs').MappingContext} [ctx.mapping] - Owning
+ *   mapping ctx, used for per-mapping sync-root resolution.
  */
-export async function detectFolderEvents({ trackingStore, onDiskAbsDirs, watchRoot }) {
+export async function detectFolderEvents({ trackingStore, onDiskAbsDirs, watchRoot, mappingId, mapping }) {
   if (!trackingStore || !watchRoot) return;
 
   // SYNC-1: defense-in-depth — if the watch root is unreachable (transient
@@ -84,7 +89,13 @@ export async function detectFolderEvents({ trackingStore, onDiskAbsDirs, watchRo
     return;
   }
 
-  const records = trackingStore.getAllOfType('collection');
+  // Multi-folder model: restrict the diff to THIS mapping's collection
+  // records, so a per-mapping scan never treats another folder's collections
+  // as deleted. Legacy single-root (no mappingId) considers all records.
+  const allCollectionRecords = trackingStore.getAllOfType('collection');
+  const records = mappingId
+    ? allCollectionRecords.filter((r) => (r && (r.mappingId || 'legacy')) === mappingId)
+    : allCollectionRecords;
 
   // ── Phase 1: collect every tracked collection that's gone from disk ─────
   const missing = [];
@@ -135,7 +146,7 @@ export async function detectFolderEvents({ trackingStore, onDiskAbsDirs, watchRo
     // accumulate such orphans. So only treat a suppressed-missing top-level
     // folder as a drip-eviction signal when its collection is still present.
     let libraryID = null;
-    try { const sr = await resolveSyncRoot(); libraryID = sr?.libraryID ?? null; } catch (_e) { libraryID = null; }
+    try { const sr = await resolveSyncRoot(mapping); libraryID = sr?.libraryID ?? null; } catch (_e) { libraryID = null; }
     if (libraryID == null) { try { libraryID = Zotero.Libraries.userLibraryID; } catch (_e) { libraryID = null; } }
     let suppressedTopLevelMissing = 0;
     for (const rec of records) {
@@ -204,6 +215,7 @@ export async function detectFolderEvents({ trackingStore, onDiskAbsDirs, watchRo
         payload: {
           collectionKey: rec.zoteroCollectionKey,
           oldRelativePath: rec.localPath,
+          mappingId: mappingId || undefined,
         },
       });
     } catch (e) {

--- a/content/index.mjs
+++ b/content/index.mjs
@@ -15,10 +15,14 @@ import * as storageStrategy from './storageStrategy.mjs';
 import * as reconcile from './reconcile.mjs';
 import * as hashCache from './_hashCache.mjs';
 import { isWatchRootUnsafe } from './utils.mjs';
+import * as mappings from './mappings.mjs';
+import {
+  getActiveMappings, readMappings, writeMappings, validateMapping, mintMappingId, LEGACY_MAPPING_ID,
+} from './mappings.mjs';
 
 // Re-export so the prefs script (which can't `import` modules from the
-// sandbox) can reach these via Zotero.WatchFolder.{warningSink,suppressionResolver,baseline,storageStrategy,reconcile}.
-export { warningSink, suppressionResolver, baseline, storageStrategy, reconcile };
+// sandbox) can reach these via Zotero.WatchFolder.{warningSink,suppressionResolver,baseline,storageStrategy,reconcile,mappings}.
+export { warningSink, suppressionResolver, baseline, storageStrategy, reconcile, mappings };
 
 // Diagnostic surface — read-only stats from the WP-A1 hash cache plus
 // a clear hook for fresh measurements. Used to verify steady-state
@@ -117,10 +121,12 @@ async function onEnabledChanged() {
 export async function runSetupWizard(window) {
     if (!Services || !Services.prompt) return false;
 
-    // v2.4: prefer the single-pane XHTML wizard. Falls back to the modal
-    // sequence below if the chrome window can't open for any reason (chrome
-    // not registered, embedding context, etc.). Both paths converge on the
-    // same `_commitWizardResult` to write prefs + start services.
+    // Single unified "add a watch folder" flow — used for first-run, the prefs
+    // "＋ Add watch folder" button, and re-run. Prefer the single-pane XHTML
+    // wizard (folder → target → confirm); fall back to the modal sequence if the
+    // chrome window can't open. Both converge on `_commitWizardResult`, which
+    // APPENDS a validated mapping to `watchMappings` (sync mode + PDF storage are
+    // global settings now, so the flow never asks per folder).
     const xhtmlResult = await _runSetupWizardXHTML(window).catch((e) => {
         try { Zotero.logError(`[WatchFolder] XHTML wizard failed, falling back to modal sequence: ${e?.message ?? e}`); } catch (_) {}
         return null; // null → fall through to the modal sequence
@@ -133,70 +139,52 @@ export async function runSetupWizard(window) {
             scopeMode: xhtmlResult.scopeMode,
             syncRootKey: xhtmlResult.syncRootKey,
             syncRootLibraryID: xhtmlResult.syncRootLibraryID,
-            modeKey: xhtmlResult.mode,
-            modeLabel: _modeLabelFor(xhtmlResult.mode),
             syncRootLabel: xhtmlResult.syncRootLabel,
-            storageStrategy: xhtmlResult.storageStrategy,
         });
         return committed;
     }
 
-    // ─── Modal-sequence fallback (pre-v2.4 path) ─────────────────
-    // ─── Step 1: welcome ─────────────────────────────────────────
-    const welcomeFlags =
-          Services.prompt.BUTTON_POS_0 * Services.prompt.BUTTON_TITLE_IS_STRING
-        | Services.prompt.BUTTON_POS_1 * Services.prompt.BUTTON_TITLE_CANCEL
-        | Services.prompt.BUTTON_POS_0_DEFAULT;
-    const welcome = Services.prompt.confirmEx(
-        window,
-        "Watch Folder — Setup",
-        "Set up Watch Folder in 5 steps?\n\n"
-          + "1. Pick a local folder the plugin should watch\n"
-          + "2. Pick the Zotero collection imports should land in\n"
-          + "3. Pick a sync mode\n"
-          + "4. Pick where PDFs should live\n"
-          + "5. Confirm and enable\n\n"
-          + "You can re-run the wizard later from Edit → Settings → Watch Folder.",
-        welcomeFlags,
-        "Continue",
-        null, null,
-        null,
-        {},
-    );
-    if (welcome !== 0) return false;
-
-    // ─── Step 2: watch folder ────────────────────────────────────
+    // ─── Modal-sequence fallback (chrome window couldn't open) ───────────
+    // Step 1: watch folder.
     const watchFolder = await _wizardPickWatchFolder(window);
     if (!watchFolder) return false;
 
-    // ─── Step 3: sync root collection ────────────────────────────
-    const syncRootChoice = await _wizardPickSyncRoot(window);
-    if (!syncRootChoice) return false;
+    // Step 2: target — whole library OR a specific collection.
+    const targetOut = {};
+    const targetOk = Services.prompt.select(
+        window, 'Watch Folder — Target',
+        `Where should files dropped in "${watchFolder}" go?`,
+        ['The whole library (Unfiled + every collection)', 'A specific collection (subfolders become subcollections)'],
+        targetOut,
+    );
+    if (!targetOk) return false;
+    let scopeMode = 'library';
+    let syncRootKey = '';
+    let syncRootLibraryID = Zotero.Libraries.userLibraryID;
+    let syncRootLabel = 'Whole library';
+    if (targetOut.value === 1) {
+        const root = await _wizardPickSyncRoot(window);
+        if (!root) return false;
+        scopeMode = 'collection';
+        syncRootKey = root.key;
+        syncRootLibraryID = root.libraryID;
+        syncRootLabel = root.label;
+    }
 
-    // ─── Step 4: sync mode ───────────────────────────────────────
-    const modeChoice = _wizardPickMode(window);
-    if (!modeChoice) return false;
-
-    // ─── Step 5: PDF storage strategy ────────────────────────────
-    const storageChoice = _wizardPickStorageStrategy(window);
-    if (!storageChoice) return false;
-
-    // ─── Step 6: confirm ─────────────────────────────────────────
+    // Step 3: confirm.
     const confirmFlags =
           Services.prompt.BUTTON_POS_0 * Services.prompt.BUTTON_TITLE_IS_STRING
         | Services.prompt.BUTTON_POS_1 * Services.prompt.BUTTON_TITLE_CANCEL
         | Services.prompt.BUTTON_POS_0_DEFAULT;
-    const safetyNote = _modeSafetyNote(modeChoice.key);
     const confirm = Services.prompt.confirmEx(
         window,
         "Watch Folder — Confirm",
-        `Ready to enable:\n\n`
-          + `Watch folder: ${watchFolder}\n`
-          + `Zotero sync root: ${syncRootChoice.label}\n`
-          + `Mode: ${modeChoice.label}\n`
-          + `PDFs: ${storageChoice.label}\n\n`
-          + `${safetyNote}\n\n`
-          + `Imports will start on the next scan cycle (default every 5s). You can change any of these in Edit → Settings → Watch Folder.`,
+        `Add this watch folder?\n\n`
+          + `Folder: ${watchFolder}\n`
+          + `Target: ${syncRootLabel}\n\n`
+          + `Import only — new files are imported into Zotero; nothing on disk is moved or deleted. `
+          + `Sync mode and PDF storage are set once for all folders in Watch Folder settings. `
+          + `Imports start on the next scan cycle (default every 5s).`,
         confirmFlags,
         "Enable",
         null, null,
@@ -206,15 +194,7 @@ export async function runSetupWizard(window) {
     if (confirm !== 0) return false;
 
     const committed = await _commitWizardResult({
-        window,
-        watchFolder,
-        scopeMode: "library",
-        syncRootKey: syncRootChoice.key,
-        syncRootLibraryID: syncRootChoice.libraryID,
-        modeKey: modeChoice.key,
-        modeLabel: modeChoice.label,
-        syncRootLabel: syncRootChoice.label,
-        storageStrategy: storageChoice.key,
+        window, watchFolder, scopeMode, syncRootKey, syncRootLibraryID, syncRootLabel,
     });
     return committed;
 }
@@ -251,11 +231,10 @@ async function _runSetupWizardXHTML(parentWindow) {
                     opened: true,
                     canceled: false,
                     watchFolder: payload.watchFolder,
+                    scopeMode: payload.scopeMode,
                     syncRootKey: payload.syncRootKey,
                     syncRootLibraryID: payload.syncRootLibraryID,
                     syncRootLabel: payload.syncRootLabel,
-                    mode: payload.mode,
-                    storageStrategy: payload.storageStrategy,
                 });
             },
         };
@@ -301,40 +280,69 @@ async function _runSetupWizardXHTML(parentWindow) {
  * @returns {Promise<boolean>} true if committed, false if blocked.
  * @private
  */
-async function _commitWizardResult({ window, watchFolder, syncRootKey, syncRootLibraryID, modeKey, modeLabel, syncRootLabel, storageStrategy, scopeMode }) {
+async function _commitWizardResult({ window, watchFolder, syncRootKey, syncRootLibraryID, syncRootLabel, scopeMode }) {
+    // Validate the candidate against existing mappings + the Zotero data dir
+    // (overlap / unsafe-root). validateMapping subsumes the old isWatchRootUnsafe
+    // check. On a reason, alert + abort WITHOUT writing any pref.
     const dataDir = Zotero?.DataDirectory?.dir;
-    const unsafeReason = isWatchRootUnsafe(watchFolder, dataDir);
-    if (unsafeReason) {
-        try { Zotero.logError(`[WatchFolder] Setup blocked: unsafe watch root "${watchFolder}" overlaps Zotero data dir "${dataDir}" — ${unsafeReason}`); } catch (_) {}
-        try {
-            if (Services && Services.prompt) {
-                Services.prompt.alert(window || null, "Watch Folder — Unsafe folder", unsafeReason);
-            }
-        } catch (_) {}
+    const reason = validateMapping({ sourcePath: watchFolder }, readMappings(), dataDir);
+    if (reason) {
+        try { Zotero.logError(`[WatchFolder] Add folder blocked: ${reason}`); } catch (_) {}
+        try { if (Services && Services.prompt) Services.prompt.alert(window || null, "Watch Folder — Cannot add folder", reason); } catch (_) {}
         return false;
     }
-    // v2.7: new setups are whole-library by default. scopeMode 'library' ignores
-    // syncRootCollectionKey, but we still persist any picked key (harmless, and
-    // it lets a user fall back to collection scope via about:config without
-    // re-picking). The collection picker is informational in library mode.
+
     const effectiveScope = scopeMode === 'collection' ? 'collection' : 'library';
-    setPref("sourcePath", watchFolder);
-    setPref("scopeMode", effectiveScope);
-    setPref("syncRootCollectionKey", syncRootKey || "");
-    if (typeof syncRootLibraryID === 'number') setPref("syncRootLibraryID", syncRootLibraryID);
-    setPref("mode", modeKey);
-    if (storageStrategy === 'stored' || storageStrategy === 'linked_watch_folder' || storageStrategy === 'stored_plus_mirror') {
-        setPref("pdfStorageStrategy", storageStrategy);
+    const mapping = {
+        id: mintMappingId(),
+        sourcePath: watchFolder,
+        scopeMode: effectiveScope,
+        syncRootCollectionKey: effectiveScope === 'collection' ? (syncRootKey || '') : '',
+        syncRootLibraryID: (typeof syncRootLibraryID === 'number') ? syncRootLibraryID : Zotero.Libraries.userLibraryID,
+        // Sync mode + PDF storage are GLOBAL (import-only enforced today); these
+        // per-mapping fields are kept only for schema shape and are ignored.
+        mode: 'mode1',
+        pdfStorageStrategy: getPref('pdfStorageStrategy') || 'stored',
+    };
+
+    const next = readMappings();
+    // Folding: on the first mapping of a legacy single-root install, keep the
+    // existing scalar-configured folder watched alongside the new one.
+    if (next.length === 0) {
+        const legacySource = getPref('sourcePath');
+        if (legacySource && legacySource !== watchFolder) {
+            next.push({
+                id: LEGACY_MAPPING_ID,
+                sourcePath: legacySource,
+                scopeMode: getPref('scopeMode') === 'library' ? 'library' : 'collection',
+                syncRootCollectionKey: getPref('syncRootCollectionKey') || '',
+                syncRootLibraryID: getPref('syncRootLibraryID') || 1,
+                mode: 'mode1',
+                pdfStorageStrategy: getPref('pdfStorageStrategy') || 'stored',
+            });
+        }
     }
-    setPref("setupCompleted", true);
-    setPref("enabled", true);
+    next.push(mapping);
+    writeMappings(next);
+    setPref('watchMappingsMulti', true);   // one unified folder-list model
+    setPref('setupCompleted', true);
+    setPref('enabled', true);
+
     try {
-        if (watchFolderService) await watchFolderService.startWatching();
+        // Re-evaluate the sync pipeline for the updated folder set, mirroring
+        // the onStartup order (coordinator first so its per-mapping baseline
+        // runs before the first scan). coordinator.start() self-gates on the
+        // effective mode — idle in Mode 1, active in Mode 2/3 — so adding a
+        // folder while in Mode 2 correctly (re)activates mirroring instead of
+        // leaving the coordinator stopped.
+        if (syncCoordinator) await syncCoordinator.stop();
+        if (watchFolderService) watchFolderService.stopWatching();
         if (syncCoordinator) await syncCoordinator.start();
+        if (watchFolderService) await watchFolderService.startWatching();
     } catch (e) {
-        Zotero.logError(`[WatchFolder] runSetupWizard: failed to start services - ${e.message}`);
+        Zotero.logError(`[WatchFolder] add folder: failed to (re)start services - ${e?.message ?? e}`);
     }
-    Zotero.debug(`[WatchFolder] Setup wizard complete (watch=${watchFolder} scope=${effectiveScope} root=${syncRootKey || '(library)'} label=${syncRootLabel} mode=${modeKey}/${modeLabel})`);
+    Zotero.debug(`[WatchFolder] Added watch folder ${mapping.id} (watch=${watchFolder} scope=${effectiveScope} target=${syncRootLabel || (effectiveScope === 'library' ? '(whole library)' : syncRootKey)})`);
     return true;
 }
 
@@ -377,7 +385,7 @@ async function _wizardPickSyncRoot(window) {
         return null;
     }
     const usable = collections
-        .filter((c) => !c.isVirtual)
+        .filter((c) => !c.isVirtual && !c.deleted)
         .map((c) => ({ key: c.key, label: _displayPath(c), libraryID }))
         .sort((a, b) => a.label.localeCompare(b.label));
     if (usable.length === 0) {
@@ -510,6 +518,165 @@ async function maybeShowFirstRunNudge(window) {
     } catch (e) {
         Zotero.logError(`[WatchFolder] first-run wizard error - ${e.message}`);
     }
+}
+
+/**
+ * Add a watch folder → target mapping. Kept as a named export for back-compat,
+ * but the flow is now unified: it delegates to {@link runSetupWizard}, the single
+ * folder → target → confirm flow used by first-run, the prefs "＋ Add watch
+ * folder" button, and re-run. Sync mode + PDF storage are global (import-only
+ * enforced today), so this never asks per folder.
+ *
+ * @param {Window} window
+ * @returns {Promise<boolean>} true if a mapping was added.
+ */
+export async function runAddMappingWizard(window) {
+  return runSetupWizard(window);
+}
+
+/**
+ * Interactive remove: pick a configured mapping and delete it (with its
+ * tracking records). Files already imported into Zotero are kept. When the last
+ * mapping is removed, multi-mapping is turned back off (the plugin reverts to
+ * the single-folder scalar config).
+ * @param {Window} window
+ * @returns {Promise<boolean>}
+ */
+export async function removeMappingInteractive(window) {
+  if (!Services || !Services.prompt) return false;
+  const list = readMappings();
+  if (list.length === 0) {
+    try { Services.prompt.alert(window, 'Watch Folder', 'No watch folders are configured.'); } catch (_) {}
+    return false;
+  }
+  const labels = list.map((m) => `${m.sourcePath}  →  ${m.scopeMode === 'library' ? '(whole library)' : (m.syncRootCollectionKey || '(collection)')}`);
+  const out = {};
+  const ok = Services.prompt.select(window, 'Watch Folder — Remove a folder',
+    'Pick a watch folder to stop watching. Files already imported into Zotero are kept; only the watch mapping and its local tracking records are removed.',
+    labels, out);
+  if (!ok) return false;
+  const victim = list[out.value];
+  if (!victim) return false;
+  return _removeMappingById(victim.id);
+}
+
+/**
+ * Remove one mapping by id, with a confirm. Used by the per-row "Remove" button
+ * in the prefs "Watch folders" list. Files already imported into Zotero are kept.
+ * @param {Window} window
+ * @param {string} id
+ * @returns {Promise<boolean>}
+ */
+export async function removeMappingById(window, id) {
+  if (!Services || !Services.prompt || !id) return false;
+  const victim = readMappings().find((m) => m.id === id);
+  if (!victim) {
+    try { Services.prompt.alert(window, 'Watch Folder', 'That watch folder is no longer configured.'); } catch (_) {}
+    return false;
+  }
+  const target = victim.scopeMode === 'library' ? '(whole library)' : (victim.syncRootCollectionKey || '(collection)');
+  const ok = Services.prompt.confirm(window, 'Remove watch folder?',
+    `Stop watching:\n${victim.sourcePath}\n→ ${target}\n\n`
+    + 'Files already imported into Zotero are kept — only this watch folder and its local tracking records are removed.');
+  if (!ok) return false;
+  return _removeMappingById(id);
+}
+
+/**
+ * Shared removal: purge the mapping's tracking records, drop it from
+ * `watchMappings`, and restart the scan loop. Stays in the unified folder-list
+ * model at zero folders (never flips the gate off — that would resurrect the
+ * legacy single-root scalars).
+ * @private
+ */
+async function _removeMappingById(id) {
+  const list = readMappings();
+  const victim = list.find((m) => m.id === id);
+  if (!victim) return false;
+  try {
+    const store = getTrackingStore();
+    if (store && typeof store.getAllOfType === 'function') {
+      for (const r of store.getAllOfType('file')) {
+        if ((r.mappingId || LEGACY_MAPPING_ID) === victim.id) store.remove(r.localPath, r.mappingId);
+      }
+      for (const c of store.getAllOfType('collection')) {
+        if ((c.mappingId || LEGACY_MAPPING_ID) === victim.id) store.removeCollectionRecord(c.zoteroCollectionKey);
+      }
+      if (typeof store.save === 'function') await store.save();
+    }
+  } catch (e) {
+    Zotero.logError(`[WatchFolder] removeMapping: purge failed - ${e?.message ?? e}`);
+  }
+
+  const remaining = list.filter((m) => m.id !== victim.id);
+  writeMappings(remaining);
+  if (remaining.length === 0) setPref('setupCompleted', false);
+  try {
+    // Re-evaluate both halves for the reduced folder set (coordinator first,
+    // mirroring onStartup). coordinator.start() self-gates on the mode, so this
+    // keeps Mode 2/3 mirroring active for the remaining folders.
+    if (syncCoordinator) await syncCoordinator.stop();
+    if (watchFolderService) watchFolderService.stopWatching();
+    if (syncCoordinator) await syncCoordinator.start();
+    if (watchFolderService) await watchFolderService.startWatching();
+  } catch (e) {
+    Zotero.logError(`[WatchFolder] removeMapping: restart failed - ${e?.message ?? e}`);
+  }
+  Zotero.debug(`[WatchFolder] Removed mapping ${victim.id}; ${remaining.length} remaining`);
+  return true;
+}
+
+/**
+ * Short human-readable summary of the active mappings, for the prefs pane.
+ * @returns {string}
+ */
+export function describeMappings() {
+  const ms = getActiveMappings().filter((m) => m && m.sourcePath);
+  if (ms.length === 0) return 'No watch folders yet — click “＋ Add watch folder…”.';
+  return `${ms.length} folder${ms.length === 1 ? '' : 's'}:\n` + ms.map((m) =>
+    `• ${m.sourcePath} → ${m.scopeMode === 'library' ? '(whole library)' : (m.syncRootCollectionKey || '(collection)')}`,
+  ).join('\n');
+}
+
+/**
+ * Health of each active mapping's Zotero target — so the prefs pane can show a
+ * "Paused" state instead of a misleading "Watching" when a target collection is
+ * gone or in the Trash (import fail-closed-pauses on such a target, see
+ * canonicalPath.resolveSyncRoot). Synchronous: reads live Zotero + prefs, no
+ * disk/await. Works for single-root (one synthesized mapping) and multi.
+ *
+ * @returns {Array<{id:string, sourcePath:string, scopeMode:string, targetLabel:string, ok:boolean, reason:(null|'trashed'|'missing'|'library-unavailable')}>}
+ */
+export function getMappingHealth() {
+  const out = [];
+  const userLib = (Zotero.Libraries && Zotero.Libraries.userLibraryID) || 1;
+  for (const m of getActiveMappings()) {
+    if (!m || !m.sourcePath) continue;
+    let ok = true;
+    let reason = null;
+    let targetLabel = '(whole library)';
+    const libraryID = m.syncRootLibraryID || userLib;
+    try {
+      if (m.scopeMode === 'library') {
+        const lib = (Zotero.Libraries && typeof Zotero.Libraries.get === 'function')
+          ? Zotero.Libraries.get(libraryID) : true;
+        if (!lib) { ok = false; reason = 'library-unavailable'; }
+      } else {
+        const key = m.syncRootCollectionKey;
+        const col = key ? Zotero.Collections.getByLibraryAndKey(libraryID, key) : null;
+        if (!col) { ok = false; reason = 'missing'; targetLabel = '(no collection set)'; }
+        else if (col.deleted) { ok = false; reason = 'trashed'; targetLabel = col.name; }
+        else { targetLabel = col.name; }
+      }
+    } catch (_e) {
+      // A thrown lookup means we can't confirm the target is healthy — treat as
+      // blocked (conservative), matching the fail-closed import pause.
+      ok = false;
+      reason = reason || 'missing';
+    }
+    out.push({ id: m.id, sourcePath: m.sourcePath, scopeMode: m.scopeMode, targetLabel, ok, reason });
+  }
+  return out;
 }
 
 export const hooks = {

--- a/content/itemAddHandler.mjs
+++ b/content/itemAddHandler.mjs
@@ -22,6 +22,8 @@
 import { resolveSyncRoot, collectionKeyToRelativePath, getScopeMode } from './canonicalPath.mjs';
 import { getPref } from './utils.mjs';
 import * as baseline from './baseline.mjs';
+import { isMultiMappingActive } from './mappings.mjs';
+import { mappingForItem } from './mappingRouter.mjs';
 
 let _observerID = null;
 let _registered = false;
@@ -138,17 +140,22 @@ async function _processBatch(batch) {
   }
   if (idSet.size === 0) return;
 
-  // Per-batch overhead — resolved ONCE.
-  let syncRoot;
-  try { syncRoot = await resolveSyncRoot(); }
-  catch (e) {
-    Zotero.logError(`[WatchFolder] itemAddHandler resolveSyncRoot: ${e?.message ?? e}`);
-    return;
+  const multi = isMultiMappingActive();
+  // Legacy single-root: resolve the one global sync root + watch root ONCE.
+  // Multi-folder: an added attachment can belong to any watch folder, so the
+  // owning mapping (and its sync/watch roots) is resolved PER ITEM below.
+  let globalSyncRoot = null;
+  let globalWatchRoot = null;
+  if (!multi) {
+    try { globalSyncRoot = await resolveSyncRoot(); }
+    catch (e) {
+      Zotero.logError(`[WatchFolder] itemAddHandler resolveSyncRoot: ${e?.message ?? e}`);
+      return;
+    }
+    if (!globalSyncRoot) return;
+    globalWatchRoot = getPref('sourcePath');
+    if (!globalWatchRoot) return;
   }
-  if (!syncRoot) return;
-
-  const watchRoot = getPref('sourcePath');
-  if (!watchRoot) return;
 
   for (const id of idSet) {
     try {
@@ -170,8 +177,27 @@ async function _processBatch(batch) {
         const parent = Zotero.Items.get(item.parentItemID);
         if (parent) owningItem = parent;
       }
-      // Gate on the owning item having at least one sync-root membership.
-      if (!_itemInSyncRoot(owningItem)) continue;
+
+      // Resolve the owning mapping + its roots. Multi: mappingForItem returns
+      // null when no watch folder owns the item (the in-scope gate). Legacy:
+      // use the global sync root + the _itemInSyncRoot scope walk.
+      let ctx = null;
+      let syncRoot = globalSyncRoot;
+      let watchRoot = globalWatchRoot;
+      if (multi) {
+        ctx = mappingForItem(owningItem);
+        if (!ctx) continue;
+        try { syncRoot = await resolveSyncRoot(ctx); }
+        catch (e) {
+          Zotero.logError(`[WatchFolder] itemAddHandler resolveSyncRoot(${ctx.id}): ${e?.message ?? e}`);
+          continue;
+        }
+        if (!syncRoot) continue;
+        watchRoot = ctx.sourcePath;
+        if (!watchRoot) continue;
+      } else if (!_itemInSyncRoot(owningItem)) {
+        continue;
+      }
 
       await baseline.copyAttachmentToCanonical({
         attachment: item,
@@ -179,6 +205,7 @@ async function _processBatch(batch) {
         syncRoot,
         watchRoot,
         store: _store,
+        ctx: ctx || undefined,
       });
       try { await _store.save(); } catch (_e) { /* logged */ }
       Zotero.debug(`[WatchFolder] itemAddHandler: copied late-attached ${item.key}`);

--- a/content/itemMembershipHandler.mjs
+++ b/content/itemMembershipHandler.mjs
@@ -40,6 +40,8 @@ import {
 import * as mirrorExecutor from './mirrorExecutor.mjs';
 import * as baseline from './baseline.mjs';
 import { getPref } from './utils.mjs';
+import { isMultiMappingActive } from './mappings.mjs';
+import { mappingForCollection } from './mappingRouter.mjs';
 
 /**
  * Handle a `collection-item` notifier event.
@@ -57,14 +59,21 @@ export async function handleCollectionItemEvent(event, compositeIDs, extraData, 
   const store = coordinator?._trackingStore;
   if (!store) return;
 
-  let syncRoot;
-  try {
-    syncRoot = await resolveSyncRoot();
-  } catch (e) {
-    Zotero.logError(`[WatchFolder] itemMembershipHandler resolveSyncRoot: ${e?.message ?? e}`);
-    return;
+  const multi = isMultiMappingActive();
+  // Legacy single-root: resolve the one global sync root up front (byte-identical
+  // to the pre-folder-list behavior). Multi-folder: the owning mapping and its
+  // sync root are resolved PER COLLECTION below, since a single batch can span
+  // collections owned by different watch folders.
+  let globalSyncRoot = null;
+  if (!multi) {
+    try {
+      globalSyncRoot = await resolveSyncRoot();
+    } catch (e) {
+      Zotero.logError(`[WatchFolder] itemMembershipHandler resolveSyncRoot: ${e?.message ?? e}`);
+      return;
+    }
+    if (!globalSyncRoot) return;
   }
-  if (!syncRoot) return;
 
   // WP-C #4: group composite ids by collection so per-collection
   // resolution (collection lookup + collectionKeyToRelativePath +
@@ -89,11 +98,27 @@ export async function handleCollectionItemEvent(event, compositeIDs, extraData, 
     } catch (_e) { continue; }
     if (!collection) continue;
 
+    // Owning mapping + its sync root for THIS collection. Multi-folder: skip
+    // collections no watch folder owns. Legacy: ctx null → global resolution.
+    let ctx = null;
+    let syncRoot = globalSyncRoot;
+    if (multi) {
+      ctx = mappingForCollection(collection);
+      if (!ctx) continue;
+      try {
+        syncRoot = await resolveSyncRoot(ctx);
+      } catch (e) {
+        Zotero.logError(`[WatchFolder] itemMembershipHandler resolveSyncRoot(${ctx.id}): ${e?.message ?? e}`);
+        continue;
+      }
+      if (!syncRoot) continue;
+    }
+
     // Sync-root scope gate — events on collections outside the configured
     // sync root are dropped. Resolved ONCE for the group.
     let collectionRelPath = null;
     try {
-      collectionRelPath = await collectionKeyToRelativePath(collection.key);
+      collectionRelPath = await collectionKeyToRelativePath(collection.key, ctx);
     } catch (e) {
       Zotero.logError(`[WatchFolder] itemMembershipHandler collectionKeyToRelativePath: ${e?.message ?? e}`);
       continue;
@@ -111,9 +136,9 @@ export async function handleCollectionItemEvent(event, compositeIDs, extraData, 
         for (const attachmentKey of attachmentKeys) {
           const record = store.getByAttachmentKey(attachmentKey);
           if (event === 'add') {
-            await _handleAdd({ record, attachmentKey, collection, item, syncRoot, store });
+            await _handleAdd({ record, attachmentKey, collection, item, syncRoot, store, ctx });
           } else {
-            await _handleRemove({ record, attachmentKey, collection, item, syncRoot, store });
+            await _handleRemove({ record, attachmentKey, collection, item, syncRoot, store, ctx });
           }
         }
       } catch (e) {
@@ -125,7 +150,7 @@ export async function handleCollectionItemEvent(event, compositeIDs, extraData, 
 
 // ─── Event handlers ────────────────────────────────────────────────────────
 
-async function _handleAdd({ record, attachmentKey, collection, item, syncRoot, store }) {
+async function _handleAdd({ record, attachmentKey, collection, item, syncRoot, store, ctx }) {
   if (!record) {
     // Untracked attachment appeared in a sync-root collection.
     //
@@ -137,14 +162,16 @@ async function _handleAdd({ record, attachmentKey, collection, item, syncRoot, s
     // create a FileRecord (spec risk #4). `copyAttachmentToCanonical` is
     // idempotent — it skips notes/links (no attachmentFilename), already-
     // tracked attachments, and files already present at the destination.
-    const baselineRoot = getPref('baselineCompletedForRoot');
-    const expectedKey = baseline.baselineKeyFor(syncRoot);
-    const baselineDone = !!baselineRoot && !!expectedKey && baselineRoot === expectedKey;
+    //
+    // Baseline-completion is per-mapping (isBaselineNeeded consults
+    // baselineCompletedByMapping for a real mapping, or the legacy scalar for
+    // single-root), so this is correct in both models.
+    const baselineDone = !(await baseline.isBaselineNeeded(ctx));
     if (!baselineDone) {
       Zotero.debug(`[WatchFolder] itemMembershipHandler: untracked attachment ${attachmentKey} added to ${collection.key} — deferring to baseline (not yet complete)`);
       return;
     }
-    const watchRoot = getPref('sourcePath');
+    const watchRoot = (ctx && ctx.sourcePath) || getPref('sourcePath');
     if (!watchRoot || !store) return;
     let attachment = null;
     try {
@@ -153,7 +180,7 @@ async function _handleAdd({ record, attachmentKey, collection, item, syncRoot, s
     if (!attachment) return;
     try {
       const result = await baseline.copyAttachmentToCanonical({
-        attachment, item, syncRoot, watchRoot, store,
+        attachment, item, syncRoot, watchRoot, store, ctx: ctx || undefined,
       });
       Zotero.debug(`[WatchFolder] itemMembershipHandler: adopted untracked attachment ${attachmentKey} into sync root → ${result}`);
     } catch (e) {
@@ -164,12 +191,12 @@ async function _handleAdd({ record, attachmentKey, collection, item, syncRoot, s
   // Idempotent union update.
   await mirrorExecutor.execute({
     type: 'addItemMembership',
-    payload: { attachmentKey, collectionKey: collection.key },
+    payload: { attachmentKey, collectionKey: collection.key, mappingId: ctx ? ctx.id : undefined },
   });
-  await _recomputeCanonicalIfChanged({ record, item, syncRoot });
+  await _recomputeCanonicalIfChanged({ record, item, syncRoot, ctx });
 }
 
-async function _handleRemove({ record, attachmentKey, collection, item, syncRoot, store }) {
+async function _handleRemove({ record, attachmentKey, collection, item, syncRoot, store, ctx }) {
   if (!record) return;
   if (!(record.collectionMembershipKeys || []).includes(collection.key)) return;
 
@@ -198,7 +225,7 @@ async function _handleRemove({ record, attachmentKey, collection, item, syncRoot
 
   await mirrorExecutor.execute({
     type: 'removeItemMembership',
-    payload: { attachmentKey, collectionKey: collection.key },
+    payload: { attachmentKey, collectionKey: collection.key, mappingId: ctx ? ctx.id : undefined },
   });
 
   if (!wasCanonical) return;
@@ -213,16 +240,16 @@ async function _handleRemove({ record, attachmentKey, collection, item, syncRoot
   // resolves via the suppression UX). Library scope: no memberships means the
   // item is now Unfiled — still in scope — so fall through and recompute the
   // canonical (→ UNFILED → move the file to the watch-folder root).
-  if (noMemberships && getScopeMode() !== 'library') return;
-  await _recomputeCanonicalIfChanged({ record: updated, item, syncRoot });
+  if (noMemberships && getScopeMode(ctx) !== 'library') return;
+  await _recomputeCanonicalIfChanged({ record: updated, item, syncRoot, ctx });
 }
 
 // ─── Canonical recompute ───────────────────────────────────────────────────
 
-async function _recomputeCanonicalIfChanged({ record, item, syncRoot }) {
+async function _recomputeCanonicalIfChanged({ record, item, syncRoot, ctx }) {
   const newCanonical = await chooseCanonicalCollection(item, syncRoot.collection, {
     existingTrackingRecord: record,
-  });
+  }, ctx);
   if (!newCanonical) return;
 
   // Library scope: chooseCanonicalCollection may return the UNFILED sentinel
@@ -242,7 +269,7 @@ async function _recomputeCanonicalIfChanged({ record, item, syncRoot }) {
   // sanitized form baseline/collectionWatcher use, so a reparent into a
   // Windows-reserved/illegal collection name mirrors correctly. ('' / null
   // pass through, preserving the scope/no-op gates below.)
-  const newRelPath = isUnfiled ? '' : await collectionKeyToDiskRelativePath(newCanonicalCollectionKey);
+  const newRelPath = isUnfiled ? '' : await collectionKeyToDiskRelativePath(newCanonicalCollectionKey, ctx);
   if (newRelPath === null) return;
 
   // The filename is preserved across the canonical move — we only change
@@ -259,6 +286,7 @@ async function _recomputeCanonicalIfChanged({ record, item, syncRoot }) {
       oldCanonicalPath: record.canonicalLocalPath,
       newCanonicalPath: newCanonicalLocalPath,
       newCanonicalCollectionKey,
+      mappingId: ctx ? ctx.id : undefined,
     },
   });
 }

--- a/content/mappingRouter.mjs
+++ b/content/mappingRouter.mjs
@@ -1,0 +1,150 @@
+/**
+ * Zotero Watch Folder — Owning-mapping router (Mode 2/3 foundation).
+ *
+ * In the folder-list model there are N watch roots on disk and N target
+ * collections in Zotero. The sync MODE is global ("same for all folders"), but
+ * every mirror event — a collection renamed, a folder deleted on disk, an item
+ * moved between collections — must be attributed to EXACTLY ONE owning mapping
+ * so it uses that mapping's watch root and sync-root. This module answers
+ * "which mapping owns this collection / item?".
+ *
+ * Ownership rule: NEAREST SYNC-ROOT ANCESTOR WINS (see docs/mode2-mode3-design.md §5).
+ * Deterministic by construction — every collection has at most one closest
+ * sync-root above it, and validateMapping rejects the only genuine tie (two
+ * mappings on the exact same sync-root / two library-scope mappings on one
+ * library), so there is never a runtime coin-flip.
+ *
+ * Leaf module: depends on mappings (registry) + canonicalPath (isSpecialCollection)
+ * only, so it introduces no import cycle.
+ */
+
+import { getActiveMappings } from './mappings.mjs';
+import { isSpecialCollection } from './canonicalPath.mjs';
+
+/** userLibraryID fallback used to normalize a mapping's (possibly absent) library. */
+function _userLibraryID() {
+  try {
+    return (Zotero.Libraries && Zotero.Libraries.userLibraryID) || 1;
+  } catch (_e) {
+    return 1;
+  }
+}
+
+/**
+ * Resolve the ONE watch-folder mapping that owns a given Zotero collection.
+ *
+ * Walks the collection's ancestor chain (itself, then parents via `parentID`).
+ * The first collection-scope mapping whose sync-root collection key sits on
+ * that chain owns it (deepest / closest ancestor, since we walk upward). If no
+ * collection-scope mapping claims it, a library-scope mapping covering the same
+ * library owns it as the fallback. Returns `null` when no watch folder covers
+ * this collection (or the collection is a virtual view).
+ *
+ * @param {object} collection - A real Zotero.Collection (not a virtual view).
+ * @returns {import('./mappings.mjs').MappingContext|null}
+ */
+export function mappingForCollection(collection) {
+  if (!collection) return null;
+
+  const mappings = getActiveMappings();
+  if (!mappings || mappings.length === 0) return null;
+
+  const libraryID = collection.libraryID;
+  const userLib = _userLibraryID();
+
+  // Partition the mappings that live in THIS collection's library by scope.
+  const collScope = [];
+  let libScope = null;
+  for (const m of mappings) {
+    if (!m) continue;
+    const mLib = m.syncRootLibraryID || userLib;
+    if (mLib !== libraryID) continue;
+    if (m.scopeMode === 'library') {
+      // First library-scope mapping for this library is the fallback owner.
+      // (validateMapping forbids a second one.)
+      if (!libScope) libScope = m;
+    } else if (m.syncRootCollectionKey) {
+      collScope.push(m);
+    }
+  }
+  if (collScope.length === 0 && !libScope) return null;
+
+  // Nearest-ancestor walk: the first collection-scope sync-root we hit going
+  // UP from the collection is the closest ancestor → the owner.
+  let cursor = collection;
+  const seen = new Set();
+  while (cursor) {
+    // A collection can never live under a virtual view, but guard the leaf
+    // anyway — isSpecialCollection is the sole scope boundary.
+    if (isSpecialCollection(cursor)) return null;
+
+    const key = cursor.key;
+    if (key) {
+      if (seen.has(key)) break; // defensive: broken parent chain / cycle
+      seen.add(key);
+      const owner = collScope.find((m) => m.syncRootCollectionKey === key);
+      if (owner) return owner;
+    }
+
+    if (!cursor.parentID) break;
+    try {
+      cursor = Zotero.Collections.get(cursor.parentID);
+    } catch (_e) {
+      break;
+    }
+  }
+
+  // No collection-scope ancestor claimed it → the library-scope mapping (if any)
+  // owns everything else in the library; otherwise nothing watches it.
+  return libScope;
+}
+
+/**
+ * Resolve the ONE watch-folder mapping that owns a given Zotero item.
+ *
+ * An item is attributed via its collection memberships: the first membership
+ * with an owning mapping wins (nearest-ancestor per collection — see
+ * {@link mappingForCollection}), matching the plugin's existing "first folder
+ * wins" philosophy for items that happen to sit in more than one watched tree.
+ * An item with no owning collection membership (e.g. Unfiled) falls back to the
+ * library-scope mapping covering the item's library, if any. Returns `null`
+ * when no watch folder covers the item.
+ *
+ * @param {object} item - A Zotero.Item (its parent, for a child attachment,
+ *   should be passed by the caller when membership lives on the parent).
+ * @returns {import('./mappings.mjs').MappingContext|null}
+ */
+export function mappingForItem(item) {
+  if (!item) return null;
+  const mappings = getActiveMappings();
+  if (!mappings || mappings.length === 0) return null;
+
+  let collectionIDs = [];
+  try {
+    collectionIDs = (typeof item.getCollections === 'function' ? item.getCollections() : []) || [];
+  } catch (_e) {
+    collectionIDs = [];
+  }
+
+  for (const id of collectionIDs) {
+    let coll = null;
+    try {
+      coll = Zotero.Collections.get(id);
+    } catch (_e) {
+      coll = null;
+    }
+    if (!coll) continue;
+    const owner = mappingForCollection(coll);
+    if (owner) return owner;
+  }
+
+  // Unfiled / no owning collection → the library-scope mapping for this
+  // item's library is the fallback owner.
+  const libraryID = item.libraryID;
+  const userLib = _userLibraryID();
+  return (
+    mappings.find(
+      (m) => m && m.scopeMode === 'library' && (m.syncRootLibraryID || userLib) === libraryID,
+    ) || null
+  );
+}

--- a/content/mappings.mjs
+++ b/content/mappings.mjs
@@ -1,0 +1,309 @@
+/**
+ * Multi-mapping registry for the Watch Folder plugin.
+ *
+ * The v2.9 feature lets the user watch MULTIPLE folders, each mapped to its own
+ * Zotero target (a collection or a whole/group library) with its own mode and
+ * storage strategy. This module is the SINGLE source of truth for the active
+ * set of (folder → target) mappings; every scan/import/mirror/safety path reads
+ * its watch root + scope from a `MappingContext` produced here instead of the
+ * global `sourcePath`/`scopeMode`/`syncRoot*` prefs.
+ *
+ * GREEN-PRESERVING GATE: while `watchMappingsMulti` is false (the default), or
+ * whenever `watchMappings` is empty/malformed, {@link getActiveMappings} returns
+ * EXACTLY ONE context synthesized from the legacy scalar prefs — so the plugin
+ * behaves byte-identically to the single-root version. Enabling the feature just
+ * swaps that one synthesized context for the N configured ones.
+ *
+ * This is a LEAF module: it imports only from `utils.mjs`, so any other module
+ * may import it without an esbuild import cycle.
+ *
+ * @module mappings
+ */
+
+import { getPref, setPref, relativePath, isWatchRootUnsafe } from './utils.mjs';
+
+/**
+ * The mapping id assigned to a migrated single-folder install (see
+ * bootstrap.js::_migrateToWatchMappings) AND the default `mappingId` on tracking
+ * records written before the feature existed. Keeping them equal means existing
+ * `…-tracking-v2.json` records resolve to the migrated mapping with no rewrite.
+ * @type {string}
+ */
+export const LEGACY_MAPPING_ID = 'legacy';
+
+const VALID_SCOPES = new Set(['library', 'collection']);
+const VALID_MODES = new Set(['mode1', 'mode2', 'mode3']);
+const VALID_STORAGE = new Set(['stored', 'linked_watch_folder', 'stored_plus_mirror']);
+
+/**
+ * @typedef {Object} MappingContext
+ * @property {string} id                    - stable, minted once, never recycled
+ * @property {string} sourcePath            - absolute watch-folder path
+ * @property {'library'|'collection'} scopeMode
+ * @property {string} syncRootCollectionKey - 8-char key; "" in library scope
+ * @property {number} syncRootLibraryID
+ * @property {'mode1'|'mode2'|'mode3'} mode
+ * @property {'stored'|'linked_watch_folder'|'stored_plus_mirror'} pdfStorageStrategy
+ */
+
+/** Test seam: when set, {@link getActiveMappings} returns this verbatim. */
+let _testMappings = null;
+let _idCounter = 0;
+
+/**
+ * Normalize a raw persisted mapping object into a {@link MappingContext},
+ * coercing/validating each field. Returns `null` when the entry is unusable
+ * (no watch folder) so callers can drop it.
+ * @param {any} raw
+ * @returns {MappingContext|null}
+ */
+function _normalize(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const sourcePath = typeof raw.sourcePath === 'string' ? raw.sourcePath : '';
+  if (!sourcePath) return null;
+  return {
+    id: (typeof raw.id === 'string' && raw.id) ? raw.id : LEGACY_MAPPING_ID,
+    sourcePath,
+    // Mirror canonicalPath.getScopeMode: anything not exactly 'library' is 'collection'.
+    scopeMode: raw.scopeMode === 'library' ? 'library' : 'collection',
+    syncRootCollectionKey: typeof raw.syncRootCollectionKey === 'string' ? raw.syncRootCollectionKey : '',
+    syncRootLibraryID: Number.isInteger(raw.syncRootLibraryID) ? raw.syncRootLibraryID : 1,
+    mode: VALID_MODES.has(raw.mode) ? raw.mode : 'mode1',
+    pdfStorageStrategy: VALID_STORAGE.has(raw.pdfStorageStrategy) ? raw.pdfStorageStrategy : 'stored',
+  };
+}
+
+/**
+ * Build the single {@link MappingContext} that reproduces today's single-root
+ * behavior from the legacy scalar prefs. `scopeMode` mirrors
+ * canonicalPath.getScopeMode exactly ('library' iff the pref is 'library').
+ * @returns {MappingContext}
+ */
+export function synthesizeLegacyMapping() {
+  return {
+    id: LEGACY_MAPPING_ID,
+    sourcePath: getPref('sourcePath') || '',
+    scopeMode: getPref('scopeMode') === 'library' ? 'library' : 'collection',
+    syncRootCollectionKey: getPref('syncRootCollectionKey') || '',
+    syncRootLibraryID: getPref('syncRootLibraryID') || 1,
+    mode: getPref('mode') || 'mode1',
+    pdfStorageStrategy: getPref('pdfStorageStrategy') || 'stored',
+  };
+}
+
+/**
+ * Whether the multi-mapping feature is switched on. While this is true the
+ * runtime treats every mapping as import-only (Mode 1) — the mirror/delete
+ * (Mode 2/3) paths per mapping are deferred to a later hardening pass, so a
+ * multi-folder setup can never propagate a deletion. Single-root installs
+ * (gate off) keep full Mode 2/3 behavior.
+ * @returns {boolean}
+ */
+export function isMultiMappingActive() {
+  return getPref('watchMappingsMulti') === true;
+}
+
+/**
+ * The effective GLOBAL sync mode, with the folder-list clamp applied.
+ *
+ * Sync mode is a single global pref ("same for all folders"). Mode 2 (mirror,
+ * no delete) is live; Mode 3 (delete) is deferred to Stage B, so while multi is
+ * active a Mode-3 pref is CLAMPED to Mode 2 — the SINGLE SOURCE OF TRUTH that
+ * keeps every delete path (mirrorExecutor delete arms, watchFolder trash paths,
+ * the coordinator lifecycle) from ever firing a deletion in the folder-list
+ * model. Single-root (multi off) returns the configured mode verbatim, so
+ * legacy Mode 3 is preserved.
+ *
+ * @returns {'mode1'|'mode2'|'mode3'}
+ */
+export function effectiveGlobalMode() {
+  const global = getPref('mode') || 'mode1';
+  if (isMultiMappingActive()) {
+    return global === 'mode1' ? 'mode1' : 'mode2';
+  }
+  return global;
+}
+
+/**
+ * The active set of mappings. The ordering is the persisted order.
+ *
+ * Returns a single synthesized-legacy context when the feature is off OR when
+ * `watchMappings` is empty/malformed (fail-safe: never leaves the plugin with
+ * zero mappings when a watch folder is configured the old way). Malformed and
+ * duplicate-id entries are dropped with a log line.
+ *
+ * @returns {MappingContext[]}
+ */
+export function getActiveMappings() {
+  if (_testMappings) return _testMappings.map((m) => ({ ...m }));
+
+  if (getPref('watchMappingsMulti') !== true) {
+    return [synthesizeLegacyMapping()];
+  }
+
+  let arr = null;
+  try { arr = JSON.parse(getPref('watchMappings') || '[]'); } catch (_e) { arr = null; }
+  if (!Array.isArray(arr)) {
+    // Malformed (parse error / not an array) while the gate is on → fail-safe to
+    // the legacy scalar rather than watch nothing on corruption.
+    return [synthesizeLegacyMapping()];
+  }
+  if (arr.length === 0) {
+    // Intentionally EMPTY (e.g. the user removed every folder) → watch nothing.
+    // Must NOT resurrect the legacy single-root scalars: in the unified
+    // folder-list model an empty list is a valid "no folders" state, and the
+    // stale scalars may point at a since-deleted collection.
+    return [];
+  }
+
+  const out = [];
+  const seenIds = new Set();
+  for (const entry of arr) {
+    const ctx = _normalize(entry);
+    if (!ctx) {
+      try { Zotero.logError(`[WatchFolder] mappings: dropping malformed entry ${JSON.stringify(entry)}`); } catch (_e) { /* */ }
+      continue;
+    }
+    if (seenIds.has(ctx.id)) {
+      try { Zotero.logError(`[WatchFolder] mappings: dropping duplicate mapping id "${ctx.id}"`); } catch (_e) { /* */ }
+      continue;
+    }
+    seenIds.add(ctx.id);
+    out.push(ctx);
+  }
+  return out.length > 0 ? out : [synthesizeLegacyMapping()];
+}
+
+/**
+ * Reverse lookup: the active {@link MappingContext} for an id (record → root),
+ * or `null`. Falls back to the synthesized legacy mapping for the legacy id so
+ * pre-feature tracking records always resolve to a root.
+ * @param {string} id
+ * @returns {MappingContext|null}
+ */
+export function getMappingById(id) {
+  if (!id) return null;
+  const found = getActiveMappings().find((m) => m.id === id);
+  if (found) return found;
+  if (id === LEGACY_MAPPING_ID) return synthesizeLegacyMapping();
+  return null;
+}
+
+/**
+ * True when two absolute watch-root paths are equal, or one contains the other.
+ * Uses the lexical {@link relativePath} containment test (returns '' for equal,
+ * a relative string when nested, `null` when unrelated).
+ * @param {string} a
+ * @param {string} b
+ * @returns {boolean}
+ */
+export function watchRootsOverlap(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string' || !a || !b) return false;
+  return relativePath(a, b) !== null || relativePath(b, a) !== null;
+}
+
+/**
+ * Config-time validation for a candidate mapping. Returns a human-readable
+ * reason string when the candidate must be REJECTED (the UI shows it and writes
+ * nothing), else `null`. Fail-closed: an unresolvable data dir still lets the
+ * user configure (isWatchRootUnsafe fails open by design), but any overlap with
+ * an existing mapping is a hard reject so every path has exactly one owner.
+ *
+ * Target (Zotero-side) collisions matter for Mode 2/3 mirroring: two folders
+ * that sync the SAME collection, or two whole-library folders on one library,
+ * have no deterministic owner. Nested/overlapping targets are ALLOWED — the
+ * runtime router picks the nearest-ancestor owner (see mappingRouter.mjs) — so
+ * only those two genuine ties are rejected here.
+ *
+ * @param {{id?: string, sourcePath: string, scopeMode?: string, syncRootCollectionKey?: string, syncRootLibraryID?: number}} candidate
+ * @param {Array<{id?: string, sourcePath: string, scopeMode?: string, syncRootCollectionKey?: string, syncRootLibraryID?: number}>} existingMappings
+ * @param {string} dataDir - Zotero.DataDirectory.dir
+ * @returns {string|null}
+ */
+export function validateMapping(candidate, existingMappings, dataDir) {
+  const path = candidate && candidate.sourcePath;
+  if (!path || typeof path !== 'string') return 'A watch folder is required.';
+  const unsafe = isWatchRootUnsafe(path, dataDir);
+  if (unsafe) return unsafe;
+
+  let userLib;
+  try { userLib = (Zotero.Libraries && Zotero.Libraries.userLibraryID) || undefined; }
+  catch (_e) { userLib = undefined; }
+  const candLib = candidate.syncRootLibraryID || userLib;
+  const candScope = candidate.scopeMode === 'library' ? 'library' : 'collection';
+  const candKey = candidate.syncRootCollectionKey || '';
+
+  for (const m of (existingMappings || [])) {
+    if (!m || typeof m.sourcePath !== 'string') continue;
+    if (candidate.id && m.id === candidate.id) continue; // editing the same row
+
+    // Disk-path overlap: watch roots may never be nested/duplicated.
+    if (watchRootsOverlap(path, m.sourcePath)) {
+      return `This folder overlaps another watch folder ("${m.sourcePath}"). `
+        + `Watch folders may not be nested inside one another or duplicated. Choose a separate folder.`;
+    }
+
+    // Target-collision (same library only). Nesting is fine; exact ties aren't.
+    const mLib = m.syncRootLibraryID || userLib;
+    if (mLib !== candLib) continue;
+    const mScope = m.scopeMode === 'library' ? 'library' : 'collection';
+    if (candScope === 'library' && mScope === 'library') {
+      return `Another watch folder already syncs the whole library. `
+        + `A library can have only one whole-library watch folder — pick a specific collection instead.`;
+    }
+    if (candScope === 'collection' && mScope === 'collection'
+        && candKey && candKey === (m.syncRootCollectionKey || '')) {
+      return `Another watch folder ("${m.sourcePath}") already syncs this collection. `
+        + `Two folders can't target the exact same collection — choose a different collection.`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Mint an 8-hex-char mapping id. Prefers crypto randomness; falls back to a
+ * time+counter token when `crypto.getRandomValues` is unavailable (e.g. tests).
+ * @returns {string}
+ */
+export function mintMappingId() {
+  try {
+    const buf = new Uint8Array(4);
+    crypto.getRandomValues(buf);
+    return Array.from(buf).map((b) => b.toString(16).padStart(2, '0')).join('');
+  } catch (_e) {
+    _idCounter += 1;
+    return ('m' + Date.now().toString(36) + _idCounter.toString(36)).slice(0, 8);
+  }
+}
+
+/**
+ * Raw read of the persisted mappings array (for the prefs-pane editor). Returns
+ * `[]` on parse failure. Does NOT apply the synthesized-legacy fallback — the UI
+ * edits the literal pref.
+ * @returns {Array<object>}
+ */
+export function readMappings() {
+  try {
+    const a = JSON.parse(getPref('watchMappings') || '[]');
+    return Array.isArray(a) ? a : [];
+  } catch (_e) {
+    return [];
+  }
+}
+
+/**
+ * Persist the mappings array back to the `watchMappings` pref.
+ * @param {Array<object>} mappings
+ */
+export function writeMappings(mappings) {
+  setPref('watchMappings', JSON.stringify(Array.isArray(mappings) ? mappings : []));
+}
+
+/**
+ * Test seam: force {@link getActiveMappings} to return the given contexts
+ * (shallow-copied). Pass `null` to restore pref-driven behavior.
+ * @param {MappingContext[]|null} arr
+ */
+export function __test_setActiveMappings(arr) {
+  _testMappings = Array.isArray(arr) ? arr.slice() : null;
+}

--- a/content/mirrorExecutor.mjs
+++ b/content/mirrorExecutor.mjs
@@ -37,6 +37,7 @@ import { createFileRecord, createCollectionRecord, STATE } from './trackingStore
 import { report as reportWarning, WARNING_CATEGORY } from './warningSink.mjs';
 import { collectionKeyToRelativePath, resolveSyncRoot, getScopeMode } from './canonicalPath.mjs';
 import { isBulkDelete, confirmBulkDelete, confirmFirstLibraryDelete } from './bulkGuard.mjs';
+import { getMappingById, effectiveGlobalMode } from './mappings.mjs';
 
 /** @type {import('./trackingStore.mjs').TrackingStore | null} */
 let _store = null;
@@ -289,10 +290,33 @@ export async function canSafelyTrashZoteroAttachment(record, attachmentItem) {
 
 // ─── Path helpers ─────────────────────────────────────────────────────────
 
-function _watchRoot() {
-  const root = getPref('sourcePath');
+function _watchRoot(ctx) {
+  // Multi-mapping: each action carries its owning mapping's watch root via ctx.
+  // Legacy single-root (ctx null / no mapping): fall back to the global pref, so
+  // every existing call path is byte-identical.
+  const root = (ctx && ctx.sourcePath) || getPref('sourcePath');
   if (!root) throw new Error('mirrorExecutor: sourcePath pref not set');
   return root;
+}
+
+/**
+ * Resolve the owning mapping context for an action payload. Returns the mapping
+ * for `payload.mappingId`, or `null` for legacy single-root actions (which then
+ * fall back to the global scalar prefs everywhere ctx is consumed). Never
+ * throws — an unknown id degrades to the legacy fallback.
+ *
+ * @param {{mappingId?: string}} [payload]
+ * @returns {import('./mappings.mjs').MappingContext|null}
+ * @private
+ */
+function _ctxFor(payload) {
+  const id = payload && payload.mappingId;
+  if (!id) return null;
+  try {
+    return getMappingById(id) || null;
+  } catch (_e) {
+    return null;
+  }
 }
 
 /**
@@ -308,9 +332,13 @@ function _watchRoot() {
  * double-join — which would produce paths like
  * `/watch//tmp/watch/file.pdf` and surface as bogus missing-file errors
  * (seen live during CONF.1).
+ *
+ * @param {string} relOrAbs
+ * @param {import('./mappings.mjs').MappingContext|null} [ctx] - Owning mapping;
+ *   resolves the correct watch root in the multi-mapping model.
  */
-function _absPath(relOrAbs) {
-  const root = _watchRoot();
+function _absPath(relOrAbs, ctx) {
+  const root = _watchRoot(ctx);
   if (!relOrAbs || relOrAbs === '') return root;
   // Already absolute? POSIX uses leading '/', Windows uses 'C:\…' or
   // 'C:/…'. Return as-is rather than joining with the watch root.
@@ -340,9 +368,10 @@ async function _createFolder(payload) {
   if (!collectionKey || typeof relativePath !== 'string' || relativePath === '') {
     return { ok: false, reason: 'invalid-payload' };
   }
+  const ctx = _ctxFor(payload);
   return _withLock(`collection:${collectionKey}`, async () => {
     let abs;
-    try { abs = _absPath(relativePath); }
+    try { abs = _absPath(relativePath, ctx); }
     catch (e) { return { ok: false, reason: 'no-watch-root', error: String(e?.message ?? e) }; }
     try {
       await IOUtils.makeDirectory(abs, { ignoreExisting: true, createAncestors: true });
@@ -393,10 +422,11 @@ async function _moveFolder(payload) {
     return { ok: false, reason: 'invalid-payload' };
   }
   return _withLock(`collection:${collectionKey}`, async () => {
+    const ctx = _ctxFor(payload);
     let oldAbs, newAbs;
     try {
-      oldAbs = _absPath(oldRelativePath);
-      newAbs = _absPath(newRelativePath);
+      oldAbs = _absPath(oldRelativePath, ctx);
+      newAbs = _absPath(newRelativePath, ctx);
     } catch (e) {
       return { ok: false, reason: 'no-watch-root', error: String(e?.message ?? e) };
     }
@@ -548,7 +578,8 @@ async function _zoteroCollectionDeleted(payload) {
   const { collectionKey, oldRelativePath } = payload;
   if (!collectionKey) return { ok: false, reason: 'invalid-payload' };
   return _withLock(`collection:${collectionKey}`, async () => {
-    const mode = getPref('mode') || 'mode1';
+    const ctx = _ctxFor(payload);
+    const mode = effectiveGlobalMode();
 
     // Mode 1 doesn't run the coordinator, so this path isn't reached
     // there. Mode 2 keeps warn-only semantics — local folder untouched,
@@ -580,7 +611,7 @@ async function _zoteroCollectionDeleted(payload) {
     // First-arm whole-library-delete gate: the first Mode-3 deletion under
     // library scope must be explicitly acknowledged (whole-library blast
     // radius). Refuses if declined or no UI — fail-safe.
-    if (!(await confirmFirstLibraryDelete({ scopeMode: getScopeMode() }))) {
+    if (!(await confirmFirstLibraryDelete({ scopeMode: getScopeMode(ctx) }))) {
       Zotero.debug(`[WatchFolder] mirrorExecutor: zoteroCollectionDeleted ${oldRelativePath || collectionKey} blocked — library-scale deletion not acknowledged`);
       return { ok: false, reason: 'library-delete-not-acknowledged' };
     }
@@ -611,7 +642,7 @@ async function _zoteroCollectionDeleted(payload) {
 
     const TRASH_DIRNAME = '.zotero-watch-trash';
     let srcAbs;
-    try { srcAbs = _absPath(oldRelativePath); }
+    try { srcAbs = _absPath(oldRelativePath, ctx); }
     catch (e) { return { ok: false, reason: 'no-watch-root', error: String(e?.message ?? e) }; }
 
     // Source already gone? Just drop tracking + return success — the
@@ -676,7 +707,7 @@ async function _zoteroCollectionDeleted(payload) {
       const blocked = [];
       for (const child of children) {
         let childAbs;
-        try { childAbs = _absPath(child.localPath); } catch (_e) { continue; }
+        try { childAbs = _absPath(child.localPath, ctx); } catch (_e) { continue; }
         const gate = await canSafelyMove(child, childAbs);
         if (gate.ok) continue;
         if (gate.reason === 'missing-file') continue;
@@ -704,12 +735,12 @@ async function _zoteroCollectionDeleted(payload) {
     // millisecond timestamp on the folder name.
     let dstRel = `${TRASH_DIRNAME}/${oldRelativePath}`;
     let dstAbs;
-    try { dstAbs = _absPath(dstRel); }
+    try { dstAbs = _absPath(dstRel, ctx); }
     catch (e) { return { ok: false, reason: 'no-watch-root', error: String(e?.message ?? e) }; }
     if (await IOUtils.exists(dstAbs).catch(() => false)) {
       const stamp = Date.now();
       dstRel = `${TRASH_DIRNAME}/${oldRelativePath}.${stamp}`;
-      dstAbs = _absPath(dstRel);
+      dstAbs = _absPath(dstRel, ctx);
     }
 
     // Pre-create parent so a cross-parent move works.
@@ -801,7 +832,8 @@ async function _localFolderDeleted(payload) {
   const { collectionKey, oldRelativePath } = payload;
   if (!collectionKey) return { ok: false, reason: 'invalid-payload' };
   return _withLock(`collection:${collectionKey}`, async () => {
-    const mode = getPref('mode') || 'mode1';
+    const ctx = _ctxFor(payload);
+    const mode = effectiveGlobalMode();
 
     if (mode !== 'mode3') {
       if (_store) {
@@ -826,13 +858,13 @@ async function _localFolderDeleted(payload) {
     }
 
     // First-arm whole-library-delete gate (see _zoteroCollectionDeleted).
-    if (!(await confirmFirstLibraryDelete({ scopeMode: getScopeMode() }))) {
+    if (!(await confirmFirstLibraryDelete({ scopeMode: getScopeMode(ctx) }))) {
       Zotero.debug(`[WatchFolder] mirrorExecutor: localFolderDeleted ${oldRelativePath || collectionKey} blocked — library-scale deletion not acknowledged`);
       return { ok: false, reason: 'library-delete-not-acknowledged' };
     }
 
     // Mode 3 — propagate the deletion to Zotero.
-    const syncRoot = await resolveSyncRoot().catch(() => null);
+    const syncRoot = await resolveSyncRoot(ctx).catch(() => null);
     const libraryID = syncRoot?.libraryID ?? Zotero.Libraries.userLibraryID;
 
     // Gather tracked child file records (under the folder path).
@@ -967,6 +999,7 @@ async function _moveItem(payload) {
   }
   return _withLock(`attachment:${attachmentKey}`, async () => {
     if (oldCanonicalPath === newCanonicalPath) return { ok: true, reason: 'no-op' };
+    const ctx = _ctxFor(payload);
 
     // Re-read the live record AFTER acquiring the lock. A prior action in the
     // same scan-cycle batch (e.g. a moveFolder that rewrote child paths) may
@@ -987,8 +1020,8 @@ async function _moveItem(payload) {
 
     let oldAbs, newAbs;
     try {
-      oldAbs = _absPath(liveSourcePath);
-      newAbs = _absPath(newCanonicalPath);
+      oldAbs = _absPath(liveSourcePath, ctx);
+      newAbs = _absPath(newCanonicalPath, ctx);
     } catch (e) {
       return { ok: false, reason: 'no-watch-root', error: String(e?.message ?? e) };
     }
@@ -1087,6 +1120,7 @@ async function _addItemMembership(payload) {
   if (!attachmentKey || !collectionKey) return { ok: false, reason: 'invalid-payload' };
   return _withLock(`attachment:${attachmentKey}`, async () => {
     if (!_store) return { ok: false, reason: 'no-store' };
+    const ctx = _ctxFor(payload);
     const rec = _store.getByAttachmentKey(attachmentKey);
     if (!rec) {
       // The collectionWatcher saw a tracked item that we don't have a
@@ -1117,7 +1151,7 @@ async function _addItemMembership(payload) {
     // stay detached — only the auto-suppressed state auto-clears.
     if (rec.state === STATE.OUT_OF_SCOPE_SUPPRESSED) {
       try {
-        const rel = await collectionKeyToRelativePath(collectionKey);
+        const rel = await collectionKeyToRelativePath(collectionKey, ctx);
         if (rel !== null) {
           updates.state = STATE.CLEAN;
           if (!rec.canonicalCollectionKey) updates.canonicalCollectionKey = collectionKey;
@@ -1136,6 +1170,7 @@ async function _removeItemMembership(payload) {
   if (!attachmentKey || !collectionKey) return { ok: false, reason: 'invalid-payload' };
   return _withLock(`attachment:${attachmentKey}`, async () => {
     if (!_store) return { ok: false, reason: 'no-store' };
+    const ctx = _ctxFor(payload);
     const rec = _store.getByAttachmentKey(attachmentKey);
     if (!rec) return { ok: false, reason: 'unknown-attachment' };
     const next = (rec.collectionMembershipKeys || []).filter((k) => k !== collectionKey);
@@ -1152,7 +1187,7 @@ async function _removeItemMembership(payload) {
     let syncRootMembershipsRemaining = 0;
     for (const k of next) {
       try {
-        const rel = await collectionKeyToRelativePath(k);
+        const rel = await collectionKeyToRelativePath(k, ctx);
         if (rel !== null) syncRootMembershipsRemaining++;
       } catch (_e) { /* sync-root unresolvable — skip count */ }
     }
@@ -1161,7 +1196,7 @@ async function _removeItemMembership(payload) {
     // Unfiled. Keep it syncing (state unchanged), clear the canonical key
     // (null = Unfiled/root); itemMembershipHandler recomputes the canonical and
     // moves the file to the watch-folder root. No suppression, no warning.
-    const libraryScope = getScopeMode() === 'library';
+    const libraryScope = getScopeMode(ctx) === 'library';
     if (syncRootMembershipsRemaining === 0 && !libraryScope) {
       updates.state = STATE.OUT_OF_SCOPE_SUPPRESSED;
       if (rec.canonicalCollectionKey) {

--- a/content/preferences.js
+++ b/content/preferences.js
@@ -120,38 +120,90 @@
         const total = sink ? sink.getTotalCount() : 0;
         countEl.value = String(total);
         row.hidden = total === 0;
+        // Inline list: auto-show + populate when there are warnings; clear+hide at 0.
+        const listEl = document.getElementById('watch-folder-warnings-list');
+        if (listEl) {
+            if (total === 0) {
+                try { while (listEl.firstChild) listEl.removeChild(listEl.firstChild); }
+                catch (_e) { listEl.textContent = ''; }
+                listEl.hidden = true;
+            } else {
+                renderWarningsList();
+                listEl.hidden = false;
+            }
+        }
         refreshAttentionStrip();
     }
 
     /**
-     * Open an alert with the recent warning entries (newest first).
-     * Caps display at the most recent 30 to keep the alert legible.
+     * Render the recent warning entries (newest first) as an inline list in the
+     * Maintenance tab. Mirrors the compact row style used by the folder list.
+     */
+    function renderWarningsList() {
+        const list = document.getElementById('watch-folder-warnings-list');
+        if (!list) return;
+        try { while (list.firstChild) list.removeChild(list.firstChild); }
+        catch (_e) { list.textContent = ''; }
+
+        const sink = Zotero.WatchFolder && Zotero.WatchFolder.warningSink;
+        const recent = sink ? sink.getRecent(50) : [];
+        if (!recent.length) {
+            const empty = document.createElement('div');
+            empty.className = 'wf-warn-empty';
+            empty.textContent = 'No warnings recorded.';
+            list.appendChild(empty);
+            return;
+        }
+
+        for (const w of recent.slice().reverse()) { // newest first
+            const item = document.createElement('div');
+            item.className = 'wf-warn-item';
+
+            const line = document.createElement('div');
+            const cat = document.createElement('span');
+            cat.className = 'wf-warn-cat';
+            cat.textContent = w.category || 'warning';
+            line.appendChild(cat);
+            const msg = document.createElement('span');
+            msg.className = 'wf-warn-msg';
+            msg.textContent = w.message || w.reason || '(no detail)';
+            line.appendChild(msg);
+            item.appendChild(line);
+
+            const where = w.path
+                || (w.collectionKey ? ('collection ' + w.collectionKey) : '')
+                || (w.attachmentKey ? ('item ' + w.attachmentKey) : '');
+            if (where) {
+                const loc = document.createElement('div');
+                loc.className = 'wf-warn-loc';
+                loc.textContent = where;
+                item.appendChild(loc);
+            }
+
+            const ts = document.createElement('div');
+            ts.className = 'wf-warn-ts';
+            try { ts.textContent = new Date(w.timestamp).toLocaleString(); }
+            catch (_e) { ts.textContent = ''; }
+            item.appendChild(ts);
+
+            list.appendChild(item);
+        }
+    }
+
+    /**
+     * Toggle the inline warnings list collapsed/expanded (re-rendering on
+     * expand so it's current). The list auto-shows via refreshWarningsDisplay
+     * when warnings exist; this just lets the user collapse a long list.
      */
     function viewWarnings() {
-        const sink = Zotero.WatchFolder && Zotero.WatchFolder.warningSink;
-        if (!sink) {
-            Services.prompt.alert(window, 'Watch Folder', 'Warning sink not available — plugin not fully loaded?');
-            return;
+        const list = document.getElementById('watch-folder-warnings-list');
+        if (!list) return;
+        if (list.hidden) {
+            renderWarningsList();
+            list.hidden = false;
+        } else {
+            list.hidden = true;
         }
-        const recent = sink.getRecent(30);
-        if (recent.length === 0) {
-            Services.prompt.alert(window, 'Watch Folder', 'No sync warnings recorded.');
-            return;
-        }
-        const lines = recent.slice().reverse().map((w) => {
-            const ts = new Date(w.timestamp).toLocaleString();
-            const where = w.path ? ` (${w.path})` : (w.collectionKey ? ` (col ${w.collectionKey})` : '');
-            return `[${w.category}] ${ts}${where}\n  ${w.message || w.reason || ''}`;
-        });
-        const counts = sink.getCountsByCategory();
-        const summary = [...counts.entries()]
-            .map(([cat, n]) => `${cat}: ${n}`)
-            .join(' · ');
-        Services.prompt.alert(
-            window,
-            'Watch Folder — Sync warnings',
-            `Total ${sink.getTotalCount()}  (${summary})\n\n${lines.join('\n\n')}`,
-        );
     }
 
     function clearWarnings() {
@@ -1033,6 +1085,10 @@
         }
         const panels = document.getElementsByClassName('wf-tabpanel');
         for (const p of panels) p.hidden = p.getAttribute('data-tab') !== name;
+        // Populate the maintenance warnings list when the tab is opened.
+        if (name === 'maintenance') {
+            try { refreshWarningsDisplay(); } catch (_e) { /* best effort */ }
+        }
     }
 
     /**
@@ -1056,6 +1112,33 @@
     };
 
     /**
+     * Active mappings whose Zotero target is blocked (collection trashed/missing,
+     * or library unavailable) — from the bundle's getMappingHealth(). These cause
+     * imports to fail-closed-pause, so the UI must surface them rather than show a
+     * misleading "Watching". Best-effort: returns [] if the bundle isn't reachable.
+     * @returns {Array<{id,sourcePath,targetLabel,ok,reason}>}
+     */
+    function blockedMappings() {
+        try {
+            const fn = Zotero.WatchFolder && Zotero.WatchFolder.getMappingHealth;
+            if (typeof fn !== 'function') return [];
+            return (fn() || []).filter((h) => h && h.ok === false);
+        } catch (_e) {
+            return [];
+        }
+    }
+
+    /** One-line summary of a blocked-target condition for the status/attention UI. */
+    function blockedSummaryText(blocked) {
+        const n = blocked.length;
+        const noun = n === 1 ? 'folder' : 'folders';
+        const cause = blocked.some((b) => b.reason === 'trashed')
+            ? 'target collection is in the Trash'
+            : 'target collection is missing';
+        return `⏸ ${n} ${noun} paused — ${cause}`;
+    }
+
+    /**
      * Refresh the persistent status header: the state pill (Not set up /
      * Paused / Watching), the "<folder> → <target>" summary, the
      * "<mode> · <storage>" detail line, and the attention strip. All reads
@@ -1075,13 +1158,52 @@
         const mode = getPref('mode') || 'mode1';
         const strategy = getStorageStrategyPref();
 
+        // Multi-mapping: when several folders are configured the single-root
+        // sourcePath/scope/mode prefs no longer describe what's being watched, so
+        // read the live mapping set instead (the scan loop watches ALL of them).
+        let multiActive = false;
+        let mappingList = [];
+        try {
+            const m = Zotero.WatchFolder && Zotero.WatchFolder.mappings;
+            if (m && typeof m.isMultiMappingActive === 'function' && m.isMultiMappingActive()) {
+                multiActive = true;
+                mappingList = (typeof m.getActiveMappings === 'function') ? m.getActiveMappings() : [];
+            }
+        } catch (_e) { /* fall back to single-root rendering */ }
+
         // State pill — Not set up → Paused → Watching.
         let state, label;
-        if (!setupCompleted || !sourcePath) { state = 'is-unset'; label = 'Not set up'; }
+        const configured = multiActive ? mappingList.length > 0 : (setupCompleted && !!sourcePath);
+        if (!configured) { state = 'is-unset'; label = 'Not set up'; }
         else if (!enabled) { state = 'is-paused'; label = 'Paused'; }
         else { state = 'is-watching'; label = 'Watching'; }
+
+        // Blocked target (collection trashed/missing) → show Paused instead of a
+        // misleading "Watching", even while enabled. The scan silently pauses on
+        // such a target, so this is the only place the user would learn why.
+        const blocked = configured && enabled ? blockedMappings() : [];
+        if (blocked.length > 0) { state = 'is-paused'; label = 'Paused'; }
         pill.className = 'wf-pill ' + state;
         pill.textContent = label;
+
+        if (multiActive) {
+            // Summary + detail describe the whole set; the per-folder targets live
+            // in the "Multiple watch folders" card below.
+            if (blocked.length > 0) {
+                summary.textContent = blockedSummaryText(blocked);
+                detail.textContent = 'Restore the collection in Zotero’s Trash, or remove that folder and re-add it with a live target.';
+            } else {
+                const n = mappingList.length;
+                // Sync mode is global; the folder-list model clamps Mode 3 → Mode 2
+                // (deletes deferred), so show the EFFECTIVE mode, not a hardcoded label.
+                const effMode = mode === 'mode1' ? 'mode1' : 'mode2';
+                const modeText = effMode === 'mode1' ? 'Import only' : 'Mirror without delete';
+                summary.textContent = `${n} folder${n === 1 ? '' : 's'} → per-folder targets`;
+                detail.textContent = `${modeText} · applies to all folders`;
+            }
+            refreshAttentionStrip();
+            return;
+        }
 
         // Summary — <folder> → <target>.
         const folderName = sourcePath ? _basename(sourcePath) : 'no folder yet';
@@ -1097,10 +1219,14 @@
                 } catch (_e) { /* leave default */ }
             }
         }
-        summary.textContent = `${folderName} → ${target}`;
-
-        // Detail — <mode> · <storage>.
-        detail.textContent = `${STATUS_MODE_LABELS[mode] || mode} · ${STATUS_STORAGE_LABELS[strategy] || strategy}`;
+        if (blocked.length > 0) {
+            summary.textContent = blockedSummaryText(blocked);
+            detail.textContent = 'Restore the collection in Zotero’s Trash, or re-run the setup wizard to pick a live target.';
+        } else {
+            summary.textContent = `${folderName} → ${target}`;
+            // Detail — <mode> · <storage>.
+            detail.textContent = `${STATUS_MODE_LABELS[mode] || mode} · ${STATUS_STORAGE_LABELS[strategy] || strategy}`;
+        }
 
         refreshAttentionStrip();
     }
@@ -1134,10 +1260,12 @@
         }
 
         const parts = [];
+        const blocked = blockedMappings();
+        if (blocked.length) parts.push(`${blocked.length} paused (target in Trash)`);
         if (warnings) parts.push(`${warnings} warning${warnings === 1 ? '' : 's'}`);
         if (suppressed) parts.push(`${suppressed} suppressed`);
         if (conflicted) parts.push(`${conflicted} conflict-blocked`);
-        const total = warnings + suppressed + conflicted;
+        const total = blocked.length + warnings + suppressed + conflicted;
         if (strip) strip.hidden = total === 0;
         if (text) text.textContent = total === 0 ? '' : `⚠ ${parts.join(' · ')} — review in Maintenance →`;
 
@@ -1262,9 +1390,10 @@
                 `Could not enumerate collections: ${e.message}`);
             return;
         }
-        // Build sorted, path-labeled options. Skip virtual collections.
+        // Build sorted, path-labeled options. Skip virtual + trashed collections
+        // (a trashed sync root pauses all imports — never let one be re-picked).
         const usable = collections
-            .filter(c => !c.isVirtual)
+            .filter(c => !c.isVirtual && !c.deleted)
             .map(c => ({ key: c.key, label: collectionDisplayPath(c) }))
             .sort((a, b) => a.label.localeCompare(b.label));
         if (usable.length === 0) {
@@ -1558,16 +1687,9 @@
                 enableCheckbox.addEventListener('command', handleEnableCommand);
             }
 
-            // Populate the read-only path display (the pref binding handles saving,
-            // but the <input readonly> won't show the saved value without this).
-            const pathInput = document.getElementById('watch-folder-source-path');
-            if (pathInput) {
-                const currentPath = getPref('sourcePath');
-                if (currentPath) pathInput.value = currentPath;
-            }
-
-            // Sync-root + mode displays — v2.
-            refreshSyncRootDisplay();
+            // Mode radio + the rest of the panels. (Source-path / sync-root rows
+            // were removed in v2.10 — the "Watch folders" list is the source of
+            // truth; the folder-list summary is refreshed below.)
             refreshModeRadio();
             refreshStorageStrategyUI();
             refreshDeletionUI();
@@ -1582,6 +1704,7 @@
 
             // Status header (pill + summary + attention strip) + default tab.
             refreshStatusHeader();
+            refreshMappingsDisplay();
             selectTab('general');
 
             Zotero.debug('[Watch Folder] Preferences panel initialized successfully');
@@ -1615,6 +1738,147 @@
         refreshStatusHeader();
     }
 
+    /** Refresh the multi-mapping summary line (import-only folder list). */
+    /** Refresh the watch-folder list — one uniform row per folder (name → target,
+     *  path, and a Watching/Paused chip from getMappingHealth). */
+    function refreshMappingsDisplay() {
+        const list = document.getElementById('watch-folder-mappings-list');
+        if (!list) return;
+        // Clear existing rows.
+        try { while (list.firstChild) list.removeChild(list.firstChild); }
+        catch (_e) { list.textContent = ''; }
+
+        let health = [];
+        try {
+            const fn = Zotero.WatchFolder && Zotero.WatchFolder.getMappingHealth;
+            if (typeof fn === 'function') health = fn() || [];
+        } catch (_e) { health = []; }
+
+        if (!health.length) {
+            const empty = document.createElement('div');
+            empty.className = 'wf-flist-empty';
+            empty.textContent = 'No watch folders yet — click “＋ Add watch folder…” below.';
+            list.appendChild(empty);
+            return;
+        }
+
+        for (const h of health) {
+            const item = document.createElement('div');
+            item.className = 'wf-fitem';
+
+            const head = document.createElement('div');
+            head.className = 'wf-fitem-head';
+
+            // Left = the watched FOLDER; right = its Zotero TARGET. Small captions
+            // make the direction unambiguous (both may share a name, e.g. test1→test1).
+            const isLib = h.scopeMode === 'library';
+
+            const fCap = document.createElement('span');
+            fCap.className = 'wf-fcap';
+            fCap.textContent = 'Folder';
+            head.appendChild(fCap);
+
+            const name = document.createElement('span');
+            name.className = 'wf-fitem-name';
+            name.textContent = _basename(h.sourcePath) || h.sourcePath || '(folder)';
+            head.appendChild(name);
+
+            const arrow = document.createElement('span');
+            arrow.className = 'wf-fitem-arrow';
+            arrow.textContent = '→';
+            head.appendChild(arrow);
+
+            const tCap = document.createElement('span');
+            tCap.className = 'wf-fcap';
+            tCap.textContent = isLib ? 'Library' : 'Collection';
+            head.appendChild(tCap);
+
+            const target = document.createElement('span');
+            target.className = 'wf-fitem-target';
+            target.textContent = h.targetLabel || (isLib ? '(whole library)' : '(collection)');
+            head.appendChild(target);
+
+            // Only surface a chip when something is WRONG (paused). "Watching" is
+            // already shown once in the header — no need to repeat it per row.
+            if (!h.ok) {
+                const chip = document.createElement('span');
+                chip.className = 'wf-fchip warn';
+                chip.textContent = h.reason === 'trashed' ? '⏸ target in Trash'
+                    : h.reason === 'missing' ? '⏸ target missing'
+                    : '⏸ paused';
+                head.appendChild(chip);
+            }
+
+            // Per-row Remove button (small, right-aligned).
+            const rm = document.createElement('button');
+            rm.className = 'wf-fremove';
+            rm.setAttribute('type', 'button');
+            rm.textContent = 'Remove';
+            rm.setAttribute('title', 'Stop watching this folder');
+            rm.addEventListener('click', () => { removeWatchFolderById(h.id); });
+            head.appendChild(rm);
+
+            item.appendChild(head);
+
+            const path = document.createElement('div');
+            path.className = 'wf-fitem-path';
+            path.textContent = h.sourcePath || '';
+            item.appendChild(path);
+
+            list.appendChild(item);
+        }
+    }
+
+    /** Add another watch folder → target mapping (switches to import-only multi). */
+    async function addWatchFolder() {
+        const fn = Zotero.WatchFolder && Zotero.WatchFolder.runAddMappingWizard;
+        if (typeof fn !== 'function') {
+            Services.prompt.alert(window, 'Watch Folder', 'Not available — plugin not fully loaded?');
+            return;
+        }
+        try {
+            await fn(window);
+        } catch (e) {
+            Services.prompt.alert(window, 'Watch Folder', `Error: ${e.message}`);
+        }
+        refreshSyncRootDisplay();
+        refreshModeRadio();
+        refreshStatusHeader();
+        refreshMappingsDisplay();
+    }
+
+    /** Remove a configured watch folder mapping (keeps already-imported items). */
+    async function removeWatchFolder() {
+        const fn = Zotero.WatchFolder && Zotero.WatchFolder.removeMappingInteractive;
+        if (typeof fn !== 'function') {
+            Services.prompt.alert(window, 'Watch Folder', 'Not available — plugin not fully loaded?');
+            return;
+        }
+        try {
+            await fn(window);
+        } catch (e) {
+            Services.prompt.alert(window, 'Watch Folder', `Error: ${e.message}`);
+        }
+        refreshStatusHeader();
+        refreshMappingsDisplay();
+    }
+
+    /** Remove ONE mapping by id (the per-row "Remove" button in the folder list). */
+    async function removeWatchFolderById(id) {
+        const fn = Zotero.WatchFolder && Zotero.WatchFolder.removeMappingById;
+        if (typeof fn !== 'function') {
+            Services.prompt.alert(window, 'Watch Folder', 'Not available — plugin not fully loaded?');
+            return;
+        }
+        try {
+            await fn(window, id);
+        } catch (e) {
+            Services.prompt.alert(window, 'Watch Folder', `Error: ${e.message}`);
+        }
+        refreshStatusHeader();
+        refreshMappingsDisplay();
+    }
+
     // Expose to window so oncommand attributes in the XHTML can reach these.
     window.WatchFolderPrefs = {
         browseForFolder,
@@ -1645,6 +1909,10 @@
         openCheckAndRepair,
         stopTrackingMissing,
         stopTrackingAllMissing,
+        // Multi-mapping (import-only): add / remove additional watch folders.
+        addWatchFolder,
+        removeWatchFolder,
+        removeWatchFolderById,
         onLoad: init,
     };
 

--- a/content/preferences.xhtml
+++ b/content/preferences.xhtml
@@ -29,6 +29,21 @@
     .wf-attention:hover { background: rgba(154,103,0,0.22); }
     .wf-attention-text { font-size: 0.9em; font-weight: 600; color: #9a6700; }
 
+    /* — Warnings list (Maintenance) — */
+    .wf-warnlist { margin-top: 6px; border: 1px solid rgba(127,127,127,0.28);
+                   border-radius: 6px; max-height: 260px; overflow-y: auto; }
+    .wf-warn-item { padding: 6px 10px; border-bottom: 1px solid rgba(127,127,127,0.16); }
+    .wf-warn-item:last-child { border-bottom: none; }
+    .wf-warn-cat { display: inline-block; font-size: 0.72em; font-weight: 700;
+                   text-transform: uppercase; letter-spacing: 0.04em; color: #9a6700;
+                   background: rgba(154,103,0,0.14); border-radius: 4px; padding: 1px 6px;
+                   margin-right: 8px; vertical-align: middle; }
+    .wf-warn-msg { font-size: 0.9em; }
+    .wf-warn-loc { font-size: 0.8em; opacity: 0.7; margin-top: 2px;
+                   word-break: break-all; font-family: ui-monospace, monospace; }
+    .wf-warn-ts { font-size: 0.75em; opacity: 0.55; margin-top: 1px; }
+    .wf-warn-empty { padding: 8px 10px; font-size: 0.9em; opacity: 0.7; }
+
     /* — Tab bar — */
     .wf-tabs { display: flex; gap: 2px; margin: 12px 0 0;
                border-bottom: 1px solid rgba(127,127,127,0.28); }
@@ -72,11 +87,36 @@
     /* — Button rows that may need to wrap (XUL hbox doesn't wrap by default;
          override display so a full row of buttons stays inside its card). — */
     .wf-btnrow { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
+
+    /* — Watch-folder list (uniform rows: name → target, path, status chip) — */
+    .wf-flist { margin: 4px 0 10px; }
+    .wf-flist-empty { font-size: 0.92em; opacity: 0.7; font-style: italic; margin: 4px 0 10px; }
+    .wf-fitem { border: 1px solid rgba(127,127,127,0.30); border-radius: 6px;
+                padding: 8px 11px; margin: 6px 0; background: rgba(127,127,127,0.04); }
+    .wf-fitem-head { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+    .wf-fcap { font-size: 0.68em; text-transform: uppercase; letter-spacing: 0.06em;
+               opacity: 0.55; font-weight: 600; }
+    .wf-fitem-name { font-weight: 600; }
+    .wf-fitem-arrow { opacity: 0.55; margin: 0 2px; }
+    .wf-fitem-target { color: #4072b8; font-weight: 600; }
+    .wf-fitem-path { font-size: 0.85em; opacity: 0.62; margin-top: 3px;
+                     word-break: break-all; font-family: ui-monospace, Menlo, monospace; }
+    .wf-fchip { margin-left: 6px; font-size: 0.8em; padding: 1px 8px; border-radius: 999px; white-space: nowrap; }
+    .wf-fchip.warn  { color: #9a6700; background: rgba(154,103,0,0.18); }
+    .wf-fremove { margin-left: auto; font-size: 0.82em; padding: 2px 10px; border-radius: 6px;
+                  border: 1px solid rgba(127,127,127,0.40); background: transparent;
+                  color: inherit; opacity: 0.75; cursor: pointer; }
+    .wf-fremove:hover { opacity: 1; border-color: #c0392b; color: #c0392b;
+                        background: rgba(192,57,43,0.08); }
   </html:style>
 
   <!-- ─── Persistent status header ───────────────────────────────── -->
   <vbox id="watch-folder-statusbar" class="wf-statusbar">
     <hbox align="center">
+      <checkbox id="watch-folder-enabled" label="Enable monitoring"
+                tooltiptext="Turns watching on or off for all watch folders"
+                preference="extensions.zotero.watchFolder.enabled"
+                style="margin-right: 10px;"/>
       <html:span id="watch-folder-status-pill" class="wf-pill is-unset"/>
       <html:span id="watch-folder-status-summary" class="wf-status-summary"/>
       <spacer flex="1"/>
@@ -90,9 +130,6 @@
         <html:a href="#" data-l10n-id="watch-folder-pref-docs-behavior"
                 onclick="WatchFolderPrefs.openDocs('test-cases'); return false;"/>
       </hbox>
-      <button id="watch-folder-setup-cta-btn" class="wf-cta"
-              data-l10n-id="watch-folder-pref-setup-cta"
-              oncommand="WatchFolderPrefs.runSetupWizard()"/>
     </hbox>
     <html:span id="watch-folder-status-detail" class="wf-status-detail"/>
     <hbox id="watch-folder-attention-strip" class="wf-attention" hidden="true"
@@ -127,33 +164,25 @@
   <vbox class="wf-tabpanel" id="wf-tabpanel-general" data-tab="general">
     <html:p data-l10n-id="watch-folder-pref-about-blurb" class="wf-lede"/>
 
+    <!-- Watch folders: the list of (folder → target) mappings. Each folder maps
+         to a specific collection or the whole library. -->
     <vbox class="wf-card">
-      <hbox align="center" class="wf-row">
-        <label data-l10n-id="watch-folder-pref-enabled" control="watch-folder-enabled"/>
-        <checkbox id="watch-folder-enabled"
-                  preference="extensions.zotero.watchFolder.enabled"/>
-      </hbox>
-
-      <hbox align="center" class="wf-row">
-        <label data-l10n-id="watch-folder-pref-source-path" control="watch-folder-source-path"/>
-        <html:input id="watch-folder-source-path" type="text" style="flex: 1;"
-                    preference="extensions.zotero.watchFolder.sourcePath"
-                    readonly="true"/>
-        <button id="watch-folder-browse-btn" data-l10n-id="watch-folder-pref-browse"
-                oncommand="WatchFolderPrefs.browseForFolder()"/>
-      </hbox>
-
-      <hbox align="center" class="wf-row">
-        <label data-l10n-id="watch-folder-pref-sync-root" control="watch-folder-sync-root-display"/>
-        <html:input id="watch-folder-sync-root-display" type="text" style="flex: 1;" readonly="true"/>
-        <button id="watch-folder-sync-root-btn" data-l10n-id="watch-folder-pref-sync-root-change"
-                oncommand="WatchFolderPrefs.pickSyncRoot()"/>
+      <html:h2 class="wf-h2">Watch folders</html:h2>
+      <html:p class="wf-desc">Each folder is imported into its own target — a specific collection or the whole library.
+        Add as many as you like. All folders share the sync mode and PDF-storage settings below.</html:p>
+      <html:div id="watch-folder-mappings-list" class="wf-flist"/>
+      <hbox align="center" class="wf-btnrow">
+        <button id="watch-folder-add-mapping-btn" label="＋ Add watch folder…"
+                oncommand="WatchFolderPrefs.addWatchFolder()"/>
       </hbox>
     </vbox>
 
-    <!-- ─── Live mode picker (click anywhere on a card to select) ── -->
+    <!-- Sync mode (GLOBAL — applies to every watch folder). Import only is the
+         only active mode today; Mirror / Mirror+delete are disabled placeholders
+         until per-folder mirror/delete lands. -->
     <vbox class="wf-card">
       <html:h2 class="wf-h2" data-l10n-id="watch-folder-pref-mode"/>
+      <html:p class="wf-desc" style="opacity: 0.85; margin: 0 0 4px 0;">Applies to all watch folders.</html:p>
       <radiogroup id="watch-folder-mode-radio">
         <vbox class="wf-opt" id="wf-mode-opt-mode1" onclick="WatchFolderPrefs.changeMode('mode1')">
           <hbox align="center">
@@ -165,24 +194,18 @@
         <vbox class="wf-opt" id="wf-mode-opt-mode2" onclick="WatchFolderPrefs.changeMode('mode2')">
           <hbox align="center">
             <radio value="mode2" data-l10n-id="watch-folder-pref-mode2-label"/>
-            <html:span class="wf-opt-current" data-l10n-id="watch-folder-pref-current-badge"/>
           </hbox>
           <html:p data-l10n-id="watch-folder-pref-mode2-desc" class="wf-opt-desc"/>
         </vbox>
-        <vbox class="wf-opt" id="wf-mode-opt-mode3" onclick="WatchFolderPrefs.changeMode('mode3')">
+        <vbox class="wf-opt" id="wf-mode-opt-mode3" style="opacity: 0.5;">
           <hbox align="center">
-            <radio value="mode3" data-l10n-id="watch-folder-pref-mode3-label"/>
-            <html:span class="wf-opt-current" data-l10n-id="watch-folder-pref-current-badge"/>
+            <radio value="mode3" data-l10n-id="watch-folder-pref-mode3-label" disabled="true"/>
+            <html:span style="margin-left: 8px; font-size: 0.85em; text-transform: uppercase; letter-spacing: 0.06em; opacity: 0.8;">Coming soon</html:span>
           </hbox>
           <html:p data-l10n-id="watch-folder-pref-mode3-desc" class="wf-opt-desc"/>
         </vbox>
       </radiogroup>
     </vbox>
-
-    <hbox align="center" class="wf-row">
-      <button id="watch-folder-rerun-wizard-btn" data-l10n-id="watch-folder-pref-rerun-wizard"
-              oncommand="WatchFolderPrefs.runSetupWizard()"/>
-    </hbox>
   </vbox>
 
   <!-- ════════════════════ STORAGE ════════════════════ -->
@@ -387,6 +410,10 @@
                 oncommand="WatchFolderPrefs.clearWarnings()"/>
       </hbox>
 
+      <!-- Inline list of recent warnings (newest first). Auto-shown when there
+           are warnings; the "View" button toggles it collapsed/expanded. -->
+      <html:div id="watch-folder-warnings-list" class="wf-warnlist" hidden="true"/>
+
       <hbox id="watch-folder-suppressed-row" align="center" hidden="true" class="wf-row">
         <label data-l10n-id="watch-folder-pref-suppressed" control="watch-folder-suppressed-count"/>
         <html:input id="watch-folder-suppressed-count" type="text" style="width: 160px;" readonly="true"/>
@@ -462,6 +489,7 @@
     <vbox class="wf-card">
       <html:h2 class="wf-h2" data-l10n-id="watch-folder-pref-section-advanced"/>
       <html:p data-l10n-id="watch-folder-pref-advanced-blurb" class="wf-desc"/>
+      <html:p class="wf-desc" style="opacity: 0.85;">These settings apply to <html:b>all</html:b> watch folders (poll interval, file types, and filename length are shared across every mapping).</html:p>
 
       <hbox align="center" class="wf-row">
         <label data-l10n-id="watch-folder-pref-poll-interval" control="watch-folder-poll-interval"/>
@@ -489,6 +517,15 @@
                     style="width: 80px;"/>
         <label data-l10n-id="watch-folder-pref-max-filename-suffix"/>
       </hbox>
+
+      <!-- Duplicate handling (GLOBAL). Dedup is by full-file content hash across
+           ALL watch folders — see docs. -->
+      <hbox align="center" class="wf-row" style="margin-top: 8px;">
+        <checkbox id="watch-folder-duplicate-check"
+                  label="Skip duplicate files (same content)"
+                  preference="extensions.zotero.watchFolder.duplicateCheck"/>
+      </hbox>
+      <html:p class="wf-desc" style="margin: 2px 0 6px 16px; opacity: 0.85;">When on, a PDF whose content already exists in Zotero is imported <html:b>once</html:b> — the same file in another watch folder is recognized and skipped (matched by content, not filename). Turn off to import every file even if identical.</html:p>
     </vbox>
   </vbox>
 

--- a/content/reconcile.mjs
+++ b/content/reconcile.mjs
@@ -29,6 +29,7 @@ import {
 } from './canonicalPath.mjs';
 import { getTrackingStore, createCollectionRecord, STATE } from './trackingStore.mjs';
 import { isWatchRootAvailable, classifyMissingFile, MISSING_CLASSIFICATION } from './fileMissing.mjs';
+import { getActiveMappings, getMappingById, isMultiMappingActive, LEGACY_MAPPING_ID } from './mappings.mjs';
 
 /**
  * Collection-record states that are "dead" — not actively syncing. A dead
@@ -61,6 +62,8 @@ const FINDING = Object.freeze({
   STALE_COLLECTION: 'stale-collection-record',
   ORPHAN_TRACKING: 'orphan-tracking',
   UNTRACKED_FOLDER: 'untracked-folder',
+  SYNC_ROOT_TRASHED: 'sync-root-trashed',
+  STALE_TRACKING: 'stale-tracking',
 });
 
 // ─── Annotation / note counting (fail-OPEN to "has value" so high-value items
@@ -149,8 +152,30 @@ export async function detect() {
   const store = getTrackingStore();
   if (!store) return { ok: false, reason: 'no-store', findings: [] };
 
-  const syncRoot = await resolveSyncRoot().catch(() => null);
-  if (!syncRoot) return { ok: false, reason: 'no-sync-root', findings: [] };
+  // Multi-mapping: the single legacy sync root no longer describes the config
+  // (and may itself be trashed). Reconcile per active mapping + a stale-record
+  // sweep, independent of the legacy scalars. Gate is off in every existing
+  // single-root test, so the legacy path below is unchanged for them.
+  if (isMultiMappingActive()) {
+    return await _detectMulti(store);
+  }
+
+  // A trashed / missing target collection makes resolveSyncRoot THROW (vs. a
+  // null return for an unconfigured root). Surface it as an actionable finding
+  // instead of the old silent `no-sync-root` bail.
+  let syncRoot = null;
+  let syncRootErr = null;
+  try { syncRoot = await resolveSyncRoot(); } catch (e) { syncRootErr = e; }
+  if (!syncRoot) {
+    if (syncRootErr) {
+      const f = _syncRootTrashedFinding({
+        id: 'f0', watchRoot: getPref('sourcePath') || '',
+        mappingId: LEGACY_MAPPING_ID, message: syncRootErr.message,
+      });
+      return { ok: true, findings: [f], highValueCount: 0 };
+    }
+    return { ok: false, reason: 'no-sync-root', findings: [] };
+  }
 
   const watchRoot = getPref('sourcePath');
   if (!watchRoot) return { ok: false, reason: 'no-watch-root', findings: [] };
@@ -310,6 +335,113 @@ export async function detect() {
 function _finding(f) { return f; }
 
 /**
+ * Build a report-only finding for a mapping whose target collection is in the
+ * Trash or missing (import pauses fail-closed on it). No auto-repair — the fix
+ * is in Zotero (restore) or Watch Folder settings (pick a new target); the only
+ * action is a no-op acknowledge.
+ */
+function _syncRootTrashedFinding({ id, watchRoot, mappingId, message }) {
+  return _finding({
+    id,
+    type: FINDING.SYNC_ROOT_TRASHED,
+    severity: 'high',
+    title: 'Watch folder paused — its Zotero target is unavailable',
+    detail: `Imports from "${watchRoot}" are paused because the target collection is in Zotero’s Trash or `
+      + `missing${message ? ` (${message})` : ''}. Restore it from Zotero’s Bin, or pick a new target for this `
+      + `folder in Watch Folder settings.`,
+    path: '',
+    attachmentKey: null,
+    counts: { annotations: 0, notes: 0, unknown: false },
+    highValue: false,
+    actions: [
+      { id: 'skip', label: 'Leave as-is (fix in Zotero or settings)', recommended: true, destructive: false },
+    ],
+    defaultActionId: 'skip',
+    _payload: { mappingId, watchRoot },
+  });
+}
+
+/**
+ * Multi-mapping detection. Two passes, both READ-ONLY:
+ *  (A) each active mapping whose target can't be resolved → SYNC_ROOT_TRASHED
+ *      (report-only visibility of a paused folder);
+ *  (B) any file record whose Zotero item is CONFIRMED trashed (found +
+ *      `deleted===true`) → STALE_TRACKING. A stale record sits in the global
+ *      content-hash index and silently blocks the file from re-importing, so
+ *      dropping it (the repair) lets the file import again into its live target.
+ *
+ * Only "found + deleted" is flagged — a "not found" lookup (e.g. a group-library
+ * key checked against the wrong library) is left alone to avoid false-positive
+ * drops. The per-mapping shadow/orphan/stale-collection drift walk is NOT run in
+ * multi mode yet (documented follow-up); import-only multi doesn't create it.
+ */
+async function _detectMulti(store) {
+  const findings = [];
+  let seq = 0;
+  const userLib = Zotero?.Libraries?.userLibraryID;
+
+  for (const ctx of getActiveMappings()) {
+    if (!ctx || !ctx.sourcePath) continue;
+    try {
+      const sr = await resolveSyncRoot(ctx);
+      if (!sr) continue; // unconfigured target for this mapping → nothing to check
+    } catch (e) {
+      findings.push(_syncRootTrashedFinding({
+        id: `f${seq++}`, watchRoot: ctx.sourcePath, mappingId: ctx.id, message: e?.message,
+      }));
+    }
+  }
+
+  for (const r of (store.getAllOfType('file') || [])) {
+    const attKey = r.zoteroAttachmentKey;
+    if (!attKey) continue;
+    // Respect explicit user intent: a detached/suppressed/conflict-blocked record
+    // is already excluded from the hash index (so it isn't blocking re-import),
+    // and flagging it for drop → re-import would reverse that choice.
+    if (NON_SYNCING_FILE_STATES.has(r.state)) continue;
+    const mid = r.mappingId || LEGACY_MAPPING_ID;
+    const m = getMappingById(mid);
+    const libraryID = (m && m.syncRootLibraryID) || userLib;
+    let att = null;
+    try { att = await Zotero.Items.getByLibraryAndKeyAsync(libraryID, attKey); } catch (_e) { att = null; }
+    if (!att || att.deleted !== true) continue; // only CONFIRMED trashed
+
+    const counts = countAnnotationsNotes(att);
+    const highValue = counts.unknown || (counts.annotations + counts.notes) > 0;
+    findings.push(_finding({
+      id: `f${seq++}`,
+      type: FINDING.STALE_TRACKING,
+      severity: highValue ? 'high' : 'medium',
+      title: 'Tracking entry points to a trashed Zotero item',
+      detail: `“${r.localPath}” is recorded as already imported, but that Zotero item is in the Trash — so the `
+        + `file won’t re-import. `
+        + (highValue
+          ? 'This trashed item has annotations/notes; restore it in Zotero rather than clearing, unless you’re sure.'
+          : 'Clear the stale entry so the file imports again into its current target.'),
+      path: r.localPath,
+      attachmentKey: attKey,
+      counts,
+      highValue,
+      actions: [
+        { id: 'drop', label: 'Clear the stale entry (file re-imports next scan)', recommended: !highValue, destructive: false },
+        { id: 'skip', label: 'Leave as-is', recommended: highValue, destructive: false },
+      ],
+      defaultActionId: highValue ? 'skip' : 'drop',
+      _payload: { mappingId: mid, localPath: r.localPath, attKey, libraryID },
+    }));
+  }
+
+  const sevRank = { high: 0, medium: 1, low: 2 };
+  findings.sort((a, b) => {
+    if (a.highValue !== b.highValue) return a.highValue ? -1 : 1;
+    const s = (sevRank[a.severity] ?? 9) - (sevRank[b.severity] ?? 9);
+    if (s !== 0) return s;
+    return a.id.localeCompare(b.id);
+  });
+  return { ok: true, findings, highValueCount: findings.filter((f) => f.highValue).length };
+}
+
+/**
  * Apply the selected repair actions. `decisions` maps finding.id → actionId.
  * Only non-skip actions run. Returns a per-action summary.
  *
@@ -320,6 +452,13 @@ function _finding(f) { return f; }
 export async function applyRepairs(findings, decisions) {
   const store = getTrackingStore();
   if (!store) return { ok: false, reason: 'no-store', applied: 0, skipped: 0, failed: 0, results: [] };
+
+  // Multi-mapping repairs (SYNC_ROOT_TRASHED / STALE_TRACKING) don't depend on
+  // the single legacy watch root, so they route around the legacy guard below.
+  if (isMultiMappingActive()) {
+    return await _applyRepairsMulti(store, findings, decisions);
+  }
+
   const syncRoot = await resolveSyncRoot().catch(() => null);
   const libraryID = syncRoot?.libraryID ?? Zotero?.Libraries?.userLibraryID;
   const watchRoot = getPref('sourcePath');
@@ -349,8 +488,54 @@ export async function applyRepairs(findings, decisions) {
   return { ok: true, applied, skipped, failed, results };
 }
 
+/**
+ * Multi-mapping apply path. Handles the two multi findings; both are
+ * additive-safe (never delete a Zotero item or a disk file).
+ *  - SYNC_ROOT_TRASHED: report-only → any action is a no-op acknowledge.
+ *  - STALE_TRACKING: `drop` removes ONLY the stale tracking record, after
+ *    re-validating that the Zotero item is STILL trashed/missing (never drop a
+ *    record whose item came back to life during the review window).
+ */
+async function _applyRepairsMulti(store, findings, decisions) {
+  const userLib = Zotero?.Libraries?.userLibraryID;
+  let applied = 0, skipped = 0, failed = 0;
+  const results = [];
+  for (const f of (findings || [])) {
+    const action = (decisions && decisions[f.id]) || f.defaultActionId;
+    if (!action || action === 'skip' || f.type === FINDING.SYNC_ROOT_TRASHED) {
+      skipped++; results.push({ id: f.id, action: 'skip', ok: true }); continue;
+    }
+    try {
+      if (f.type === FINDING.STALE_TRACKING && action === 'drop') {
+        const { localPath, attKey, mappingId, libraryID } = f._payload || {};
+        let att = null;
+        try { att = await Zotero.Items.getByLibraryAndKeyAsync(libraryID ?? userLib, attKey); } catch (_e) { att = null; }
+        // Re-validate: only drop while the item is STILL trashed/missing.
+        if (att && att.deleted !== true) {
+          failed++; results.push({ id: f.id, action, ok: false, reason: 'state-changed: item is live again' });
+          continue;
+        }
+        store.remove(localPath, mappingId);
+        applied++; results.push({ id: f.id, action, ok: true });
+      } else {
+        failed++; results.push({ id: f.id, action, ok: false, reason: 'unsupported-in-multi' });
+      }
+    } catch (e) {
+      failed++;
+      results.push({ id: f.id, action, ok: false, reason: String(e?.message ?? e) });
+      try { Zotero.logError(`[WatchFolder] reconcile apply (multi) ${f.id}/${action}: ${e?.message ?? e}`); } catch (_e) { /* */ }
+    }
+  }
+  try { await store.save(); } catch (_e) { /* logged */ }
+  return { ok: true, applied, skipped, failed, results };
+}
+
 async function _applyOne(f, action, { store, libraryID, watchRoot }) {
   switch (f.type) {
+    case FINDING.SYNC_ROOT_TRASHED:
+      // Report-only in the legacy path too (its sole action is 'skip', so this
+      // is a defensive no-op the loop won't normally reach).
+      return { ok: true };
     case FINDING.SHADOW_ORPHANED: {
       if (action !== 'rehome') return { ok: false, reason: 'unknown-action' };
       const { attKey, survivingLocalPath, allSurvivingLocalPaths, folderRel, canonicalLocalPath } = f._payload;

--- a/content/setupWizard.js
+++ b/content/setupWizard.js
@@ -65,6 +65,7 @@ const WatchFolderSetup = (function () {
   const state = {
     step: 1,
     watchFolder: "",
+    scopeMode: "collection",
     syncRootKey: "",
     syncRootLibraryID: 1,
     syncRootLabel: "",
@@ -104,7 +105,7 @@ const WatchFolderSetup = (function () {
     const enable = $("btn-enable");
     if (n === 1) back.setAttribute("hidden", "hidden");
     else back.removeAttribute("hidden");
-    if (n === 5) {
+    if (n === 3) {
       next.setAttribute("hidden", "hidden");
       enable.removeAttribute("hidden");
     } else {
@@ -112,9 +113,12 @@ const WatchFolderSetup = (function () {
       enable.setAttribute("hidden", "hidden");
     }
 
-    // Per-step entry hooks. Step 2 is now an informational whole-library
-    // explainer (library scope is the only model) — no collection to populate.
-    if (n === 5) renderConfirm();
+    // Per-step entry hooks. Step 2 lets the user choose whole-library scope or a
+    // specific sync-root collection; the collection list is populated lazily the
+    // first time "A specific collection" is selected. Sync mode + PDF storage are
+    // now global settings (all folders), so the wizard is folder → target → confirm.
+    if (n === 2) _syncScopePicker();
+    if (n === 3) renderConfirm();
   }
 
   function validateStep(n) {
@@ -127,17 +131,13 @@ const WatchFolderSetup = (function () {
       return true;
     }
     if (n === 2) {
-      // Whole-library scope — nothing to pick; the panel is informational.
-      return true;
-    }
-    if (n === 3) {
-      const checked = document.querySelector('input[name="mode"]:checked');
-      state.mode = checked ? checked.value : "mode1";
-      return true;
-    }
-    if (n === 4) {
-      const checked = document.querySelector('input[name="storage"]:checked');
-      state.storageStrategy = checked ? checked.value : "stored";
+      const checked = document.querySelector('input[name="scope"]:checked');
+      state.scopeMode = checked && checked.value === "collection" ? "collection" : "library";
+      if (state.scopeMode === "collection" && !state.syncRootKey) {
+        $("coll-error").textContent = "Pick a collection to continue, or choose “Whole library” above.";
+        return false;
+      }
+      $("coll-error").textContent = "";
       return true;
     }
     return true;
@@ -145,7 +145,7 @@ const WatchFolderSetup = (function () {
 
   function next() {
     if (!validateStep(state.step)) return;
-    if (state.step < 5) showStep(state.step + 1);
+    if (state.step < 3) showStep(state.step + 1);
   }
 
   function back() {
@@ -158,17 +158,15 @@ const WatchFolderSetup = (function () {
   }
 
   function enable() {
-    if (!validateStep(3)) return;
-    if (!validateStep(4)) return;
+    if (!validateStep(1)) { showStep(1); return; }
+    if (!validateStep(2)) { showStep(2); return; }
     _onResult({
       canceled: false,
       watchFolder: state.watchFolder,
-      scopeMode: "library",
-      syncRootKey: state.syncRootKey,
+      scopeMode: state.scopeMode,
+      syncRootKey: state.scopeMode === "collection" ? state.syncRootKey : "",
       syncRootLibraryID: state.syncRootLibraryID,
-      syncRootLabel: state.syncRootLabel,
-      mode: state.mode,
-      storageStrategy: state.storageStrategy,
+      syncRootLabel: state.scopeMode === "collection" ? state.syncRootLabel : "Whole library",
     });
     _safeWindow().close();
   }
@@ -197,6 +195,40 @@ const WatchFolderSetup = (function () {
     }
   }
 
+  // ─── Step 2: scope choice (whole library vs. one collection) ──────────
+
+  /**
+   * Wire the scope radios and show/hide the collection picker. Populates the
+   * collection list lazily the first time "A specific collection" is active, so
+   * an all-library setup never pays the enumeration cost. Idempotent — safe to
+   * call on every entry to step 2.
+   */
+  function _syncScopePicker() {
+    const radios = document.querySelectorAll('input[name="scope"]');
+    const picker = $("coll-picker");
+    const apply = () => {
+      const checked = document.querySelector('input[name="scope"]:checked');
+      const isCollection = !!(checked && checked.value === "collection");
+      state.scopeMode = isCollection ? "collection" : "library";
+      if (picker) picker.hidden = !isCollection;
+      if (isCollection) {
+        populateCollections();
+      } else {
+        // Reverting to whole-library clears any stale collection pick so the
+        // confirm/summary and committed prefs stay consistent.
+        state.syncRootKey = "";
+        state.syncRootLabel = "";
+        $("coll-error").textContent = "";
+      }
+    };
+    radios.forEach((r) => {
+      if (r.dataset.wired === "1") return;
+      r.addEventListener("change", apply);
+      r.dataset.wired = "1";
+    });
+    apply();
+  }
+
   // ─── Step 2: collection list ──────────────────────────────────────────
 
   function _displayPath(collection) {
@@ -221,9 +253,9 @@ const WatchFolderSetup = (function () {
     return d;
   }
 
-  function populateCollections() {
+  function populateCollections(force) {
     const list = $("coll-list");
-    if (list.dataset.populated === "1") return;
+    if (!force && list.dataset.populated === "1") return;
 
     const libraryID = (typeof Zotero !== "undefined" && Zotero.Libraries)
       ? Zotero.Libraries.userLibraryID : 1;
@@ -246,12 +278,8 @@ const WatchFolderSetup = (function () {
       }))
       .sort((a, b) => a.label.localeCompare(b.label));
 
-    if (usable.length === 0) {
-      $("coll-error").textContent =
-        "No collections found in your library. Create a collection in Zotero, then re-run setup.";
-      return;
-    }
-
+    // NB: no early "no collections" bail — the user can create one with the
+    // "＋ Create" control below even when the library has none yet.
     list.innerHTML = "";
     for (const u of usable) {
       const row = document.createElement("div");
@@ -278,6 +306,43 @@ const WatchFolderSetup = (function () {
       list.appendChild(row);
     }
     list.dataset.populated = "1";
+
+    // Reflect the currently-selected key (e.g. a just-created collection).
+    if (state.syncRootKey) {
+      const sel = list.querySelector(`.coll-row[data-key="${state.syncRootKey}"]`);
+      if (sel) sel.setAttribute("data-selected", "1");
+    }
+  }
+
+  /**
+   * Create a new collection in the user library from the "＋ Create" input, then
+   * re-render the list and select it. Runs in the wizard's chrome context, so it
+   * uses the live Zotero.Collection API (async saveTx).
+   */
+  async function createNewCollection() {
+    const input = $("new-coll-name");
+    const name = input && input.value ? input.value.trim() : "";
+    if (!name) {
+      $("coll-error").textContent = "Type a name for the new collection first.";
+      return;
+    }
+    try {
+      const libraryID = (typeof Zotero !== "undefined" && Zotero.Libraries)
+        ? Zotero.Libraries.userLibraryID : 1;
+      const coll = new Zotero.Collection();
+      coll.libraryID = libraryID;
+      coll.name = name;
+      await coll.saveTx();
+      // Select the new collection and re-render so it appears in the list.
+      state.syncRootLibraryID = libraryID;
+      state.syncRootKey = coll.key;
+      state.syncRootLabel = _displayPath(coll);
+      if (input) input.value = "";
+      $("coll-error").textContent = "";
+      populateCollections(true);
+    } catch (e) {
+      $("coll-error").textContent = `Could not create collection: ${e && e.message ? e.message : e}`;
+    }
   }
 
   // ─── Step 4: confirm + safety note ────────────────────────────────────
@@ -287,6 +352,22 @@ const WatchFolderSetup = (function () {
     if (mode === "mode2") return "Mode 2 — Mirror without delete";
     if (mode === "mode3") return "Mode 3 — Mirror with safe delete";
     return mode;
+  }
+
+  /**
+   * The CURRENT effective global sync mode, so the confirm step reflects the
+   * user's actual selection instead of a hardcoded "Import only". Sync mode is
+   * global (set once in Watch Folder settings); the folder-list model clamps a
+   * Mode-3 pref to Mode 2 (deletes deferred), so mirror the same clamp here to
+   * avoid promising safe-delete that won't run yet.
+   */
+  function _currentMode() {
+    try {
+      const m = (Zotero && Zotero.Prefs && Zotero.Prefs.get("extensions.zotero.watchFolder.mode", true)) || "mode1";
+      const multi = !!(Zotero && Zotero.Prefs && Zotero.Prefs.get("extensions.zotero.watchFolder.watchMappingsMulti", true) === true);
+      if (multi && m === "mode3") return "mode2";
+      return (m === "mode1" || m === "mode2" || m === "mode3") ? m : "mode1";
+    } catch (_e) { return "mode1"; }
   }
 
   function _modeSafetyText(mode) {
@@ -310,18 +391,23 @@ const WatchFolderSetup = (function () {
   }
 
   function renderConfirm() {
-    const checkedMode = document.querySelector('input[name="mode"]:checked');
-    state.mode = checkedMode ? checkedMode.value : state.mode;
-    const checkedStorage = document.querySelector('input[name="storage"]:checked');
-    state.storageStrategy = checkedStorage ? checkedStorage.value : state.storageStrategy;
     $("sum-folder").textContent = state.watchFolder || "—";
-    $("sum-coll").textContent = "Whole library";
-    $("sum-mode").textContent = _modeLabel(state.mode);
-    const storageEl = $("sum-storage");
-    if (storageEl) storageEl.textContent = _storageLabel(state.storageStrategy);
+    $("sum-coll").textContent = state.scopeMode === "collection"
+      ? (state.syncRootLabel || "(collection)")
+      : "Whole library";
+    // Sync mode + PDF storage are global (set once in Watch Folder settings), so
+    // the confirm step doesn't restate storage per folder — but it DOES reflect
+    // the current effective sync mode so the note matches the user's selection
+    // (e.g. "Mirror without delete" once they've switched off Import only).
+    const mode = _currentMode();
     const note = $("safety-note");
-    note.className = "safety-note " + state.mode;
-    note.textContent = _modeSafetyText(state.mode);
+    if (note) {
+      // CSS keys are m1 (green/safe) / m3 (red/danger); m2 falls through to the
+      // neutral base style. Matches the current effective mode.
+      const cls = mode === "mode1" ? "m1" : mode === "mode3" ? "m3" : "m2";
+      note.className = "safety-note " + cls;
+      note.textContent = `${_modeLabel(mode)}. ${_modeSafetyText(mode)} Sync mode and PDF storage are set once for all folders in Watch Folder settings.`;
+    }
   }
 
   // ─── Init ─────────────────────────────────────────────────────────────
@@ -332,6 +418,12 @@ const WatchFolderSetup = (function () {
     $("btn-next").addEventListener("click", next);
     $("btn-enable").addEventListener("click", enable);
     $("folder-browse").addEventListener("click", browseFolder);
+    const createBtn = $("new-coll-create");
+    if (createBtn) createBtn.addEventListener("click", () => { createNewCollection(); });
+    const nameInput = $("new-coll-name");
+    if (nameInput) nameInput.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") { e.preventDefault(); createNewCollection(); }
+    });
 
     // Close button on the title bar is a cancel too
     window.addEventListener("unload", () => {

--- a/content/setupWizard.xhtml
+++ b/content/setupWizard.xhtml
@@ -209,7 +209,7 @@
 
   <div class="wizard-header">
     <h1>Watch Folder Setup</h1>
-    <div class="step-indicator">Step <span id="step-num">1</span> of 5</div>
+    <div class="step-indicator">Step <span id="step-num">1</span> of 3</div>
   </div>
 
   <!-- ============ Step 1: pick watch folder ============ -->
@@ -227,95 +227,52 @@
     <div class="error" id="folder-error"></div>
   </div>
 
-  <!-- ============ Step 2: pick sync root collection ============ -->
+  <!-- ============ Step 2: how the folder maps (whole library OR one collection) ============ -->
   <div class="step" id="step-collection" data-step="2">
     <h2>2. How the watch folder maps to Zotero</h2>
     <p class="lede">
-      Watch Folder mirrors your <strong>whole library</strong>. You don't pick a
-      single collection — the layout maps automatically:
+      Choose what this folder maps to. You can add more folders later — each with
+      its own target — from Edit → Settings → Watch Folder.
     </p>
-    <ul>
-      <li>A PDF dropped at the <strong>top level</strong> of the watch folder becomes an <strong>Unfiled</strong> item.</li>
-      <li>Each <strong>top-level folder</strong> maps to a top-level collection; nested folders map to nested collections (created as needed).</li>
-      <li>Zotero's Trash and special views (Duplicates, Unfiled, saved searches) are never mirrored.</li>
-    </ul>
+    <fieldset class="modes">
+      <legend>Target</legend>
+
+      <label class="mode-option">
+        <input type="radio" name="scope" value="collection" checked="checked"/>
+        <span class="mode-title">A specific collection</span>
+        <span class="mode-desc">Everything imported from this folder lands under one collection you pick. Subfolders on disk become subcollections under it.</span>
+      </label>
+
+      <label class="mode-option">
+        <input type="radio" name="scope" value="library"/>
+        <span class="mode-title">Whole library</span>
+        <span class="mode-desc">The folder mirrors your entire library: a PDF at the <b>top level</b> becomes an <b>Unfiled</b> item, each top-level folder maps to a top-level collection (nested folders → nested collections, created as needed), and Zotero's Trash and special views (Duplicates, Unfiled, saved searches) are never mirrored.</span>
+      </label>
+    </fieldset>
+
+    <div id="coll-picker" hidden="hidden">
+      <p class="lede" style="margin-top:12px">Pick the collection to import into:</p>
+      <div class="coll-list" id="coll-list"></div>
+      <div id="new-coll-row" style="display:flex; gap:8px; margin-top:10px; align-items:center;">
+        <input id="new-coll-name" type="text" placeholder="New collection name…" style="flex:1;"/>
+        <button id="new-coll-create" type="button">＋ Create</button>
+      </div>
+    </div>
     <div class="error" id="coll-error"></div>
   </div>
 
-  <!-- ============ Step 3: pick mode ============ -->
-  <div class="step" id="step-mode" data-step="3">
-    <h2>3. Pick a sync mode</h2>
-    <p class="lede">
-      How aggressively should Zotero and your folder stay in sync?
-      You can change this later from the preferences pane.
-    </p>
-    <fieldset class="modes">
-      <legend>Sync mode</legend>
-
-      <label class="mode-option">
-        <input type="radio" name="mode" value="mode1" checked="checked"/>
-        <span class="mode-title">Mode 1 — Import only</span>
-        <span class="mode-desc">Files dropped into your folder are imported into Zotero. Renames and deletes don't propagate in either direction. <b>Safest mode</b> — recommended for trying out the plugin.</span>
-      </label>
-
-      <label class="mode-option">
-        <input type="radio" name="mode" value="mode2"/>
-        <span class="mode-title">Mode 2 — Mirror without delete</span>
-        <span class="mode-desc">Two-way sync of collections and items: rename a collection in Zotero, the folder renames on disk; move an item between collections, the file moves on disk. Destructive operations (deletes) are <b>warn-only</b>.</span>
-      </label>
-
-      <label class="mode-option">
-        <input type="radio" name="mode" value="mode3"/>
-        <span class="mode-title">Mode 3 — Mirror with safe delete</span>
-        <span class="mode-desc">Full two-way sync including deletes. Files trashed by either side go to a recoverable <code>.zotero-watch-trash/</code> directory under your watch root. Any operation affecting &gt;10 files or &gt;20% of your tree prompts for confirmation.</span>
-      </label>
-    </fieldset>
-  </div>
-
-  <!-- ============ Step 4: PDF storage strategy ============ -->
-  <div class="step" id="step-storage" data-step="4">
-    <h2>4. Where should PDFs live?</h2>
-    <p class="lede">
-      Zotero syncs your metadata, notes, and highlights. PDF <em>files</em> are
-      separate — this picks where they're stored. You can change it later.
-    </p>
-    <fieldset class="modes">
-      <legend>PDF storage strategy</legend>
-
-      <label class="mode-option">
-        <input type="radio" name="storage" value="stored" checked="checked"/>
-        <span class="mode-title">Store PDFs in Zotero</span>
-        <span class="mode-desc">Best Zotero experience. Zotero manages PDFs and can sync them using Zotero Storage or WebDAV. Uses Zotero file storage if file sync is enabled.</span>
-      </label>
-
-      <label class="mode-option">
-        <input type="radio" name="storage" value="linked_watch_folder"/>
-        <span class="mode-title">Link PDFs from watch folder</span>
-        <span class="mode-desc">Saves Zotero Storage space. PDFs stay in your watch folder; use a folder-sync tool (pCloud, Dropbox, OneDrive, Syncthing…) to back them up. <b>May not open in Zotero mobile apps.</b></span>
-      </label>
-
-      <label class="mode-option">
-        <input type="radio" name="storage" value="stored_plus_mirror"/>
-        <span class="mode-title">Store in Zotero and mirror to watch folder</span>
-        <span class="mode-desc">Keeps Zotero's normal stored copy plus a copy in the watch folder. Redundant backup/export; does not save Zotero Storage space.</span>
-      </label>
-    </fieldset>
-  </div>
-
-  <!-- ============ Step 5: confirm ============ -->
-  <div class="step" id="step-confirm" data-step="5">
-    <h2>5. Confirm</h2>
+  <!-- ============ Step 3: confirm ============ -->
+  <div class="step" id="step-confirm" data-step="3">
+    <h2>3. Confirm</h2>
     <p class="lede">
       Review your choices. After "Enable", the plugin will start watching
       on the next scan cycle (default every 5 seconds).
     </p>
     <dl class="summary">
       <dt>Watch folder</dt><dd id="sum-folder">—</dd>
-      <dt>Scope</dt><dd id="sum-coll">—</dd>
-      <dt>Mode</dt><dd id="sum-mode">—</dd>
-      <dt>PDFs</dt><dd id="sum-storage">—</dd>
+      <dt>Target</dt><dd id="sum-coll">—</dd>
     </dl>
-    <p class="safety-note" id="safety-note">—</p>
+    <p class="safety-note mode1" id="safety-note">Import only — files dropped in this folder are imported into Zotero. Nothing on disk is moved or deleted. Sync mode and PDF storage are set once for all folders in Watch Folder settings.</p>
   </div>
 
   <div class="wizard-footer">

--- a/content/storageStrategy.mjs
+++ b/content/storageStrategy.mjs
@@ -46,7 +46,11 @@ export const STRATEGY = Object.freeze({
  * (soft migration — the only way importMode is `linked` is an explicit
  * choice, since its default is `stored`).
  */
-export function getStorageStrategy() {
+export function getStorageStrategy(explicit) {
+  // Per-mapping override: when a mapping supplies its own storage strategy,
+  // honor it directly (multi-mapping). Falls back to the global pref otherwise.
+  if (explicit === STRATEGY.LINKED_WATCH_FOLDER || explicit === STRATEGY.STORED_PLUS_MIRROR) return explicit;
+  if (explicit === STRATEGY.STORED) return STRATEGY.STORED;
   const s = getPref('pdfStorageStrategy');
   if (s === STRATEGY.LINKED_WATCH_FOLDER || s === STRATEGY.STORED_PLUS_MIRROR) return s;
   if ((!s || s === STRATEGY.STORED) && getPref('importMode') === 'linked') {

--- a/content/syncCoordinator.mjs
+++ b/content/syncCoordinator.mjs
@@ -27,6 +27,7 @@
  */
 
 import { getPref } from './utils.mjs';
+import { isMultiMappingActive, getActiveMappings, effectiveGlobalMode } from './mappings.mjs';
 import * as collectionWatcher from './collectionWatcher.mjs';
 import * as itemAddHandler from './itemAddHandler.mjs';
 import * as mirrorExecutor from './mirrorExecutor.mjs';
@@ -106,7 +107,7 @@ export class SyncCoordinator {
 
   /** Mode pref changed at runtime — start or stop accordingly. */
   async _onModeChanged() {
-    const mode = getPref('mode') || 'mode1';
+    const mode = effectiveGlobalMode();
     const enabled = !!getPref('enabled');
     if (mode === 'mode1' && this._running) {
       Zotero.debug('[WatchFolder] SyncCoordinator: mode→mode1 at runtime, stopping');
@@ -126,19 +127,27 @@ export class SyncCoordinator {
       Zotero.debug('[WatchFolder] SyncCoordinator.start: not initialized — skipping');
       return;
     }
-    const mode = getPref('mode') || 'mode1';
+    const mode = effectiveGlobalMode();
     if (mode === 'mode1') {
       Zotero.debug('[WatchFolder] SyncCoordinator: Mode 1 — staying idle');
       return;
     }
     if (this._running) return;
     // Phase C — first-run baseline. Idempotent (skips when the sync-root
-    // key matches the persisted `baselineCompletedForRoot` pref).
-    // MUST run before collectionWatcher registers; otherwise the
-    // mkdirs/copies issued here would race with notifier events the
-    // baseline itself indirectly triggers.
+    // key matches the persisted completion pref). MUST run before
+    // collectionWatcher registers; otherwise the mkdirs/copies issued here
+    // would race with notifier events the baseline itself indirectly triggers.
+    // Multi-folder: run once PER watch folder (each has its own sync root +
+    // per-mapping completion via baselineCompletedByMapping).
     try {
-      await baseline.runBaseline({ trackingStore: this._trackingStore });
+      if (isMultiMappingActive()) {
+        for (const ctx of getActiveMappings()) {
+          if (!ctx || !ctx.sourcePath) continue;
+          await baseline.runBaseline({ trackingStore: this._trackingStore, mapping: ctx });
+        }
+      } else {
+        await baseline.runBaseline({ trackingStore: this._trackingStore });
+      }
     } catch (e) {
       Zotero.logError(`[WatchFolder] SyncCoordinator: baseline failed - ${e?.message ?? e}`);
     }
@@ -182,6 +191,8 @@ export class SyncCoordinator {
    * @param {Array<{path: string}>} ctx.scannedFiles
    * @param {Set<string>} ctx.onDiskAbsDirs - Absolute dir paths under watchRoot.
    * @param {string} ctx.watchRoot
+   * @param {string} [ctx.mappingId] - Owning mapping (multi-folder model).
+   * @param {import('./mappings.mjs').MappingContext} [ctx.mapping] - Owning mapping ctx.
    */
   async notifyScanCycle(ctx) {
     if (!this._running) return;
@@ -190,6 +201,8 @@ export class SyncCoordinator {
         trackingStore: this._trackingStore,
         onDiskAbsDirs: ctx?.onDiskAbsDirs,
         watchRoot: ctx?.watchRoot,
+        mappingId: ctx?.mappingId,
+        mapping: ctx?.mapping,
       });
     } catch (e) {
       Zotero.logError(`[WatchFolder] SyncCoordinator.notifyScanCycle: ${e?.message ?? e}`);

--- a/content/trackingStore.mjs
+++ b/content/trackingStore.mjs
@@ -22,6 +22,28 @@ const TRACKING_FILENAME = 'zotero-watch-folder-tracking-v2.json';
 const SCHEMA_VERSION = 2;
 
 /**
+ * Default `mappingId` for records written before the multi-mapping feature (or
+ * by the synthesized single mapping). MUST equal mappings.mjs::LEGACY_MAPPING_ID
+ * — a plain constant here (not an import) keeps this store a leaf module with no
+ * dependency on the mappings registry.
+ */
+const LEGACY_MAPPING_ID = 'legacy';
+
+/**
+ * Compose the `_files` Map key. A file's identity is (owning mapping, path):
+ * the same relative filename ("Methods/x.pdf") can legitimately exist under two
+ * different watch roots pointed at different targets, so the mapping id must
+ * partition the primary store or the two would collide onto one record. NUL is
+ * used as the delimiter because it can never appear in a path segment.
+ * @param {string} mappingId
+ * @param {string} localPath
+ * @returns {string}
+ */
+function _fileKey(mappingId, localPath) {
+  return `${mappingId || LEGACY_MAPPING_ID}\u0000${localPath}`;
+}
+
+/**
  * States that should remain queryable by content hash for dedup. Any
  * record state OUTSIDE this set (e.g. user-detached, suppressed,
  * conflict-blocked) is intentionally excluded from `_byHash` so a fresh
@@ -113,6 +135,7 @@ export const STATE = Object.freeze({
 export function createFileRecord(data) {
   return {
     type: 'file',
+    mappingId: data.mappingId ?? LEGACY_MAPPING_ID,
     localPath: data.localPath ?? '',
     canonicalLocalPath: data.canonicalLocalPath ?? data.localPath ?? '',
     lastSyncedHash: data.lastSyncedHash ?? null,
@@ -136,6 +159,7 @@ export function createFileRecord(data) {
 export function createCollectionRecord(data) {
   return {
     type: 'collection',
+    mappingId: data.mappingId ?? LEGACY_MAPPING_ID,
     localPath: data.localPath ?? '',
     zoteroCollectionKey: data.zoteroCollectionKey ?? '',
     parentCollectionKey: data.parentCollectionKey ?? null,
@@ -150,6 +174,7 @@ export function createCollectionRecord(data) {
 export function createTombstoneRecord(data) {
   return {
     type: 'tombstone',
+    mappingId: data.mappingId ?? LEGACY_MAPPING_ID,
     objectType: data.objectType ?? 'file',
     localPath: data.localPath ?? '',
     canonicalLocalPath: data.canonicalLocalPath ?? null,
@@ -301,10 +326,12 @@ export class TrackingStore {
       Zotero.debug('[WatchFolder] TrackingStore: file record missing localPath');
       return;
     }
-    if (this._files.has(record.localPath)) {
-      this._files.delete(record.localPath); // move-to-end semantics
+    if (!record.mappingId) record.mappingId = LEGACY_MAPPING_ID;
+    const key = _fileKey(record.mappingId, record.localPath);
+    if (this._files.has(key)) {
+      this._files.delete(key); // move-to-end semantics
     }
-    this._files.set(record.localPath, record);
+    this._files.set(key, record);
     this._evictIfNeeded();
     this._rebuildIndexes();
     this._dirty = true;
@@ -420,11 +447,11 @@ export class TrackingStore {
    *   key missed (e.g. an absolute path passed where a sync-root-relative key
    *   was stored). Callers on data-safety paths should treat false as a bug.
    */
-  update(localPath, updates) {
+  update(localPath, updates, mappingId = LEGACY_MAPPING_ID) {
     this._ensureInitialized();
-    const rec = this._files.get(localPath);
+    const rec = this._files.get(_fileKey(mappingId, localPath));
     if (!rec) {
-      Zotero.debug(`[WatchFolder] TrackingStore.update: no file record at ${localPath}`);
+      Zotero.debug(`[WatchFolder] TrackingStore.update: no file record at ${localPath} (mapping ${mappingId})`);
       return false;
     }
     Object.assign(rec, updates);
@@ -437,9 +464,9 @@ export class TrackingStore {
    * Remove a file record by localPath.
    * @returns {boolean} true if removed.
    */
-  remove(localPath) {
+  remove(localPath, mappingId = LEGACY_MAPPING_ID) {
     this._ensureInitialized();
-    const removed = this._files.delete(localPath);
+    const removed = this._files.delete(_fileKey(mappingId, localPath));
     if (removed) {
       this._rebuildIndexes();
       this._dirty = true;
@@ -464,10 +491,12 @@ export class TrackingStore {
     // Snapshot first: remove() mutates _files and rebuilds the index.
     const matches = [];
     for (const rec of this._files.values()) {
-      if (rec && rec.zoteroAttachmentKey === attachmentKey) matches.push(rec.localPath);
+      if (rec && rec.zoteroAttachmentKey === attachmentKey) {
+        matches.push({ localPath: rec.localPath, mappingId: rec.mappingId });
+      }
     }
-    for (const localPath of matches) {
-      if (this.remove(localPath)) removedAny = true;
+    for (const m of matches) {
+      if (this.remove(m.localPath, m.mappingId)) removedAny = true;
     }
     return removedAny;
   }
@@ -496,9 +525,9 @@ export class TrackingStore {
   // ─── Queries ───────────────────────────────────────────────────────────
 
   /** @returns {FileRecord|null} */
-  getByLocalPath(localPath) {
+  getByLocalPath(localPath, mappingId = LEGACY_MAPPING_ID) {
     this._ensureInitialized();
-    return this._files.get(localPath) ?? null;
+    return this._files.get(_fileKey(mappingId, localPath)) ?? null;
   }
 
   /** @returns {FileRecord|null} */
@@ -575,9 +604,9 @@ export class TrackingStore {
   }
 
   /** Convenience: does a file record exist at this path? */
-  hasPath(localPath) {
+  hasPath(localPath, mappingId = LEGACY_MAPPING_ID) {
     this._ensureInitialized();
-    return this._files.has(localPath);
+    return this._files.has(_fileKey(mappingId, localPath));
   }
 
   /**
@@ -915,16 +944,24 @@ export class TrackingStore {
       // local actor crafted the tracking JSON.
       for (const rec of (data.files ?? [])) {
         if (rec?.localPath && rec.type === 'file') {
-          this._files.set(rec.localPath, sanitizeUntrustedKeys(rec));
+          const clean = sanitizeUntrustedKeys(rec);
+          if (!clean.mappingId) clean.mappingId = LEGACY_MAPPING_ID;
+          this._files.set(_fileKey(clean.mappingId, clean.localPath), clean);
         }
       }
       for (const rec of (data.collections ?? [])) {
         if (rec?.zoteroCollectionKey && rec.type === 'collection') {
-          this._collections.set(rec.zoteroCollectionKey, sanitizeUntrustedKeys(rec));
+          const clean = sanitizeUntrustedKeys(rec);
+          if (!clean.mappingId) clean.mappingId = LEGACY_MAPPING_ID;
+          this._collections.set(rec.zoteroCollectionKey, clean);
         }
       }
       for (const rec of (data.tombstones ?? [])) {
-        if (rec?.type === 'tombstone') this._tombstones.push(sanitizeUntrustedKeys(rec));
+        if (rec?.type === 'tombstone') {
+          const clean = sanitizeUntrustedKeys(rec);
+          if (!clean.mappingId) clean.mappingId = LEGACY_MAPPING_ID;
+          this._tombstones.push(clean);
+        }
       }
       this._rebuildIndexes();
       this._dirty = false;

--- a/content/watchFolder.mjs
+++ b/content/watchFolder.mjs
@@ -6,7 +6,7 @@
 
 import { getPref, setPref, delay, getFileHash, relativePath } from './utils.mjs';
 import { hashFile as _hashFileCached } from './_hashCache.mjs';
-import { scanFolder, scanFolderRecursive, SKIP_DIRNAMES } from './fileScanner.mjs';
+import { scanFolder, scanFolderRecursive, scanTree, SKIP_DIRNAMES } from './fileScanner.mjs';
 import { importFile, handlePostImportAction } from './fileImporter.mjs';
 import { TrackingStore, initTrackingStore, createFileRecord, createCollectionRecord, createTombstoneRecord, STATE } from './trackingStore.mjs';
 import { renameAttachment } from './fileRenamer.mjs';
@@ -30,6 +30,23 @@ import {
   MISSING_CLASSIFICATION,
   STATE_FOR_CLASSIFICATION,
 } from './fileMissing.mjs';
+import {
+  getActiveMappings,
+  getMappingById,
+  synthesizeLegacyMapping,
+  isMultiMappingActive,
+  effectiveGlobalMode,
+  LEGACY_MAPPING_ID,
+} from './mappings.mjs';
+
+/**
+ * How often (in scan cycles) `_scanMapping` discards its per-mapping directory
+ * cache and does a full uncached walk. The mtime short-circuit in `scanTree`
+ * elides per-file work for unchanged directories; this periodic full sweep is
+ * the backstop for filesystems that report unreliable directory mtimes (some
+ * cloud clients), bounding the worst-case latency for a missed change.
+ */
+const FULL_SWEEP_EVERY_SCANS = 12;
 
 /**
  * Main service class for watch folder functionality
@@ -75,6 +92,17 @@ export class WatchFolderService {
 
     /** @type {Object|null} Reference to SyncCoordinator for v2.1 scan-cycle bridge */
     this._syncCoordinator = null;
+
+    /**
+     * Per-mapping directory-scan cache for the incremental `scanTree` walk.
+     * Keyed by mapping id → a Map keyed by absolute dir path. Cleared on stop
+     * and periodically swept (see FULL_SWEEP_EVERY_SCANS).
+     * @type {Map<string, Map<string, {mtime: number, files: Array, subdirs: string[]}>>}
+     */
+    this._dirScanCache = new Map();
+
+    /** @type {number} Monotonic scan-cycle counter driving the periodic full sweep. */
+    this._scanCounter = 0;
   }
 
   /**
@@ -95,6 +123,28 @@ export class WatchFolderService {
   setSyncCoordinator(coordinator) {
     this._syncCoordinator = coordinator;
     Zotero.debug('[WatchFolder] SyncCoordinator connected');
+  }
+
+  /**
+   * Effective sync mode for a mapping. Sync mode is GLOBAL in the folder-list
+   * model ("same for all folders"), so the per-mapping `ctx.mode` is ignored
+   * when multi is active. Mode 2 (mirror, no delete) is live; Mode 3 (delete)
+   * is deferred to Stage B, so a Mode-3 pref is CLAMPED to Mode 2 here — a
+   * multi-folder setup can mirror structure but can never trash a file or item
+   * yet. In single-root mode this returns the configured mode unchanged, so
+   * Mode 2/3 behavior is fully preserved for existing single-root installs.
+   * @param {import('./mappings.mjs').MappingContext} [ctx]
+   * @returns {'mode1'|'mode2'|'mode3'}
+   * @private
+   */
+  _effectiveMode(ctx) {
+    if (isMultiMappingActive()) {
+      // Folder-list model: mode is GLOBAL (ctx.mode ignored) and clamped so
+      // Mode 3 deletes stay off until Stage B — single source of truth in
+      // mappings.effectiveGlobalMode.
+      return effectiveGlobalMode();
+    }
+    return (ctx && ctx.mode) || getPref('mode') || 'mode1';
   }
 
   /**
@@ -198,30 +248,37 @@ export class WatchFolderService {
       await this.init();
     }
 
-    const watchPath = getPref('sourcePath');
-    if (!watchPath) {
+    const mappings = getActiveMappings();
+    const configured = mappings.filter(m => m && m.sourcePath);
+    if (configured.length === 0) {
       Zotero.debug('[WatchFolder] No watch path configured');
       return;
     }
 
-    // Verify path exists
-    try {
-      const exists = await IOUtils.exists(watchPath);
-      if (!exists) {
-        Zotero.debug(`[WatchFolder] Watch path does not exist: ${watchPath}`);
+    // Single-root: keep the pre-flight existence check (existing behavior/tests
+    // rely on startWatching being a no-op when the sole path doesn't exist). In
+    // multi mode each mapping's folder is verified per scan cycle instead
+    // (scanFolderRecursive returns [] for a missing/unreachable root).
+    if (!isMultiMappingActive() && configured.length === 1) {
+      const watchPath = configured[0].sourcePath;
+      try {
+        const exists = await IOUtils.exists(watchPath);
+        if (!exists) {
+          Zotero.debug(`[WatchFolder] Watch path does not exist: ${watchPath}`);
+          return;
+        }
+      } catch (e) {
+        Zotero.logError(e);
+        Zotero.debug(`[WatchFolder] Error checking watch path: ${e.message}`);
         return;
       }
-    } catch (e) {
-      Zotero.logError(e);
-      Zotero.debug(`[WatchFolder] Error checking watch path: ${e.message}`);
-      return;
     }
 
     this._isWatching = true;
     this._emptyScans = 0;
     this._currentInterval = (getPref('pollInterval') || 5) * 1000;
 
-    Zotero.debug(`[WatchFolder] Started watching: ${watchPath}`);
+    Zotero.debug(`[WatchFolder] Started watching ${configured.length} mapping(s)`);
 
     // Run initial scan immediately
     await this._scan();
@@ -253,6 +310,9 @@ export class WatchFolderService {
       clearTimeout(this._pollTimer);
       this._pollTimer = null;
     }
+
+    // Drop the incremental scan caches so a re-enable does a clean full walk.
+    this._dirScanCache.clear();
 
     Zotero.debug('[WatchFolder] Stopped watching');
   }
@@ -342,147 +402,48 @@ export class WatchFolderService {
     this._scanInProgress = true;
 
     try {
-      const watchPath = getPref('sourcePath');
-      if (!watchPath) {
-        return;
-      }
+      // Advance the scan-cycle counter (drives the periodic full sweep in
+      // _scanMapping) once per cycle, regardless of how many mappings run.
+      this._scanCounter++;
 
-      // Scan for files recursively
-      const files = await scanFolderRecursive(watchPath);
-
-      // ── Detect folder renames BEFORE per-file logic ──────────────────
-      // If the user renamed a subfolder on disk, rename the corresponding
-      // Zotero subcollection (same key, new name) and update descendant
-      // tracking records so per-file move detection sees a consistent
-      // state on the very same scan.
-      try {
-        await this._detectFolderRenames(files, watchPath);
-      } catch (e) {
-        Zotero.debug(`[WatchFolder] Folder-rename detection failed: ${e.message}`);
-      }
-
-      // ── B.4 / EF.1 — empty-folder pickup ─────────────────────────────
-      // Files imported into a subfolder trigger subcollection creation
-      // as a side effect of canonicalPath.relativePathToCollection. But
-      // a user who creates an empty subfolder (or a subfolder with only
-      // skipped/ignored files) expects an empty Zotero subcollection
-      // too. Walk the disk dirs and create collections for any not yet
-      // tracked.
-      try {
-        await this._ensureCollectionsForExistingFolders(watchPath);
-      } catch (e) {
-        Zotero.debug(`[WatchFolder] Empty-folder pickup failed: ${e.message}`);
-      }
-
-      // ── A2 — folderEventDetector hook ────────────────────────────────
-      // Bridge the scan cycle into the v2.1 sync pipeline. Gated on
-      // coordinator.isRunning() so Mode 1 doesn't pay the recursive
-      // _listSubdirectories cost every poll interval (review fix B7).
-      // Runs AFTER folder-rename and empty-folder pickup so the
-      // disk-side view is settled.
-      if (this._syncCoordinator
-          && typeof this._syncCoordinator.isRunning === 'function'
-          && this._syncCoordinator.isRunning()) {
+      // Multi-mapping: scan each active (folder → target) mapping SERIALLY so
+      // the single tracking store never interleaves writes across mappings. In
+      // single-root mode getActiveMappings() returns one synthesized legacy
+      // mapping, so this is byte-identical to the pre-feature behavior.
+      let totalNew = 0;
+      const activeIds = new Set();
+      for (const ctx of getActiveMappings()) {
+        if (!ctx || !ctx.sourcePath) continue;
+        activeIds.add(ctx.id);
         try {
-          // SYNC-1: never run the folder-deletion pass when the watch root
-          // is unreachable (transient unmount / disconnected drive). On an
-          // unavailable root the on-disk dir set collapses and every tracked
-          // folder would look deleted → mass-trash. Gate behind the same
-          // availability check used by _handleExternalDeletions.
-          const rootAvailable = await isWatchRootAvailable(watchPath);
-          if (!rootAvailable) {
-            Zotero.debug('[WatchFolder] Watch root unavailable — skipping folder-deletion scan');
-          } else {
-            const onDiskAbsDirs = new Set([watchPath, ...(await this._listSubdirectories(watchPath))]);
-            await this._syncCoordinator.notifyScanCycle({
-              scannedFiles: files,
-              onDiskAbsDirs,
-              watchRoot: watchPath,
-            });
-          }
+          totalNew += await this._scanMapping(ctx);
         } catch (e) {
-          Zotero.debug(`[WatchFolder] SyncCoordinator scan-cycle notify failed: ${e.message}`);
+          Zotero.logError(`[WatchFolder] scan cycle for mapping ${ctx.id} failed: ${e && e.message ? e.message : e}`);
         }
       }
 
-      // Detect externally-deleted files vs file-moves. A "move" is when a
-      // tracked file's path disappears AND an untracked file with the same
-      // content hash appears elsewhere — common case is the user
-      // reorganising the watch folder by dragging a file into a subfolder.
-      // Moves update the tracking record + move the Zotero item to the new
-      // subfolder's collection without ever sending it to the bin.
-      try {
-        const diskPaths = new Set(files.map(f => f.path));
-        await this._handleExternalDeletions(diskPaths, files);
-      } catch (e) {
-        Zotero.debug(`[WatchFolder] External-deletion scan failed: ${e.message}`);
+      // Drop scan caches for mappings that are no longer active (removed folder)
+      // so stale directory snapshots can't linger.
+      for (const id of [...this._dirScanCache.keys()]) {
+        if (!activeIds.has(id)) this._dirScanCache.delete(id);
       }
 
-      // Filter out already tracked and currently processing files
-      const newFiles = [];
-      for (const fileInfo of files) {
-        const filePath = fileInfo.path;
-
-        // Skip if currently being processed
-        if (this._processingFiles.has(filePath)) {
-          continue;
-        }
-
-        // Skip if already tracked. Check BOTH the absolute and the
-        // sync-root-relative form — v2 spec records use relative paths,
-        // but legacy writers in this module sometimes wrote absolute.
-        // Without the relative check, baseline-written records (which
-        // are properly relative) would be missed and the dedup-skip
-        // path would insert a duplicate at the absolute key (#25).
-        if (this._trackingStore) {
-          if (this._trackingStore.hasPath(filePath)) continue;
-          const relForLookup = relativePath(filePath, watchPath);
-          if (relForLookup != null && this._trackingStore.hasPath(relForLookup)) {
-            continue;
-          }
-        }
-
-        // Compute the sync-root-relative directory for this file. The sync
-        // root collection itself maps to "" (the watch-folder root). A file
-        // in a subfolder yields its relative directory, e.g. "Methods/AI".
-        const rel = relativePath(filePath, watchPath); // null if not under watch
-        let relativeDir = '';
-        if (rel != null && rel !== '') {
-          const parts = rel.split('/');
-          parts.pop(); // drop filename
-          relativeDir = parts.join('/');
-        }
-        Zotero.debug(`[WatchFolder] ${filePath} → sync-root dir "${relativeDir}"`);
-        newFiles.push({ path: filePath, relativeDir });
-      }
-
-      if (newFiles.length > 0) {
-        Zotero.debug(`[WatchFolder] Found ${newFiles.length} new file(s)`);
-
-        // Reset adaptive polling when files found
+      // Adaptive polling is per-service — driven by the AGGREGATE new-file
+      // count across all mappings this cycle.
+      if (totalNew > 0) {
         this._emptyScans = 0;
         this._currentInterval = (getPref('pollInterval') || 5) * 1000;
-
-        // Process new files
-        for (const fileObj of newFiles) {
-          await this._processNewFile(fileObj.path, fileObj.relativeDir);
-        }
       } else {
-        // Increment empty scan counter for adaptive polling
         this._emptyScans++;
-
-        // After 10 consecutive empty scans, increase interval (up to 2x)
         if (this._emptyScans >= 10) {
           const baseInterval = (getPref('pollInterval') || 5) * 1000;
           const maxInterval = baseInterval * 2;
-
           if (this._currentInterval < maxInterval) {
             this._currentInterval = Math.min(this._currentInterval * 1.2, maxInterval);
             Zotero.debug(`[WatchFolder] Increased poll interval to ${this._currentInterval}ms`);
           }
         }
       }
-
     } catch (e) {
       Zotero.logError(e);
       Zotero.debug(`[WatchFolder] Scan error: ${e.message}`);
@@ -503,6 +464,130 @@ export class WatchFolderService {
   }
 
   /**
+   * Scan a single (folder → target) mapping. All watch-root / scope reads come
+   * from `ctx`, and every tracking mutation is scoped to `ctx.id`, so mappings
+   * never cross-contaminate. Returns the number of new files processed this
+   * cycle (fed into the caller's aggregate adaptive-polling counter).
+   *
+   * @param {import('./mappings.mjs').MappingContext} ctx
+   * @returns {Promise<number>}
+   * @private
+   */
+  async _scanMapping(ctx) {
+    const watchPath = ctx.sourcePath;
+    if (!watchPath) {
+      return 0;
+    }
+
+    // Incremental scan: reuse this mapping's directory cache so unchanged
+    // folders skip the per-file stat walk. Periodically discard it for a full
+    // sweep (backstop for filesystems with unreliable directory mtimes).
+    let cache = this._dirScanCache.get(ctx.id);
+    if (!cache) {
+      cache = new Map();
+      this._dirScanCache.set(ctx.id, cache);
+    }
+    if (this._scanCounter % FULL_SWEEP_EVERY_SCANS === 0) {
+      cache.clear();
+    }
+
+    // Scan for files recursively (and collect the subdir set in the same walk,
+    // so the folder-rename / empty-folder / deletion passes don't each re-walk).
+    const { files, dirs } = await scanTree(watchPath, cache);
+
+    // ── Detect folder renames BEFORE per-file logic ──────────────────
+    try {
+      await this._detectFolderRenames(files, watchPath, ctx, dirs);
+    } catch (e) {
+      Zotero.debug(`[WatchFolder] Folder-rename detection failed: ${e.message}`);
+    }
+
+    // ── B.4 / EF.1 — empty-folder pickup ─────────────────────────────
+    try {
+      await this._ensureCollectionsForExistingFolders(watchPath, ctx, dirs);
+    } catch (e) {
+      Zotero.debug(`[WatchFolder] Empty-folder pickup failed: ${e.message}`);
+    }
+
+    // ── A2 — folderEventDetector hook ────────────────────────────────
+    if (this._syncCoordinator
+        && typeof this._syncCoordinator.isRunning === 'function'
+        && this._syncCoordinator.isRunning()) {
+      try {
+        // SYNC-1: never run the folder-deletion pass when this mapping's watch
+        // root is unreachable (transient unmount / disconnected drive).
+        const rootAvailable = await isWatchRootAvailable(watchPath);
+        if (!rootAvailable) {
+          Zotero.debug(`[WatchFolder] Watch root unavailable (mapping ${ctx.id}) — skipping folder-deletion scan`);
+        } else {
+          // Reuse the subdir set from this cycle's scanTree walk (dirs), instead
+          // of a second full tree walk via _listSubdirectories.
+          const onDiskAbsDirs = new Set([watchPath, ...dirs]);
+          await this._syncCoordinator.notifyScanCycle({
+            scannedFiles: files,
+            onDiskAbsDirs,
+            watchRoot: watchPath,
+            mappingId: ctx.id,
+            mapping: ctx,
+          });
+        }
+      } catch (e) {
+        Zotero.debug(`[WatchFolder] SyncCoordinator scan-cycle notify failed: ${e.message}`);
+      }
+    }
+
+    // Detect externally-deleted files vs file-moves — scoped to THIS mapping's
+    // records (a per-mapping scan must never treat another mapping's files as
+    // deleted).
+    try {
+      const diskPaths = new Set(files.map(f => f.path));
+      await this._handleExternalDeletions(diskPaths, files, ctx);
+    } catch (e) {
+      Zotero.debug(`[WatchFolder] External-deletion scan failed: ${e.message}`);
+    }
+
+    // Filter out already tracked (within this mapping) and currently processing.
+    const newFiles = [];
+    for (const fileInfo of files) {
+      const filePath = fileInfo.path;
+
+      // Skip if currently being processed (absolute paths are globally unique
+      // across non-overlapping mappings, so the bare path key is unambiguous).
+      if (this._processingFiles.has(filePath)) {
+        continue;
+      }
+
+      // Skip if already tracked in THIS mapping. Check BOTH the absolute and the
+      // relative form (v2 records are relative; legacy writers sometimes absolute).
+      if (this._trackingStore) {
+        if (this._trackingStore.hasPath(filePath, ctx.id)) continue;
+        const relForLookup = relativePath(filePath, watchPath);
+        if (relForLookup != null && this._trackingStore.hasPath(relForLookup, ctx.id)) {
+          continue;
+        }
+      }
+
+      const rel = relativePath(filePath, watchPath); // null if not under watch
+      let relativeDir = '';
+      if (rel != null && rel !== '') {
+        const parts = rel.split('/');
+        parts.pop(); // drop filename
+        relativeDir = parts.join('/');
+      }
+      Zotero.debug(`[WatchFolder] [${ctx.id}] ${filePath} → sync-root dir "${relativeDir}"`);
+      newFiles.push({ path: filePath, relativeDir });
+    }
+
+    if (newFiles.length > 0) {
+      Zotero.debug(`[WatchFolder] mapping ${ctx.id}: found ${newFiles.length} new file(s)`);
+      for (const fileObj of newFiles) {
+        await this._processNewFile(fileObj.path, fileObj.relativeDir, ctx);
+      }
+    }
+    return newFiles.length;
+  }
+
+  /**
    * Process a newly detected file. v2: resolves the target collection via
    * canonicalPath (sync-root-relative), builds a v2 file record, and uses
    * `zoteroAttachmentKey` as the stable identity.
@@ -513,7 +598,9 @@ export class WatchFolderService {
    *   ("" for files at the root), used to resolve the target collection.
    * @returns {Promise<void>}
    */
-  async _processNewFile(filePath, relativeDir = '') {
+  async _processNewFile(filePath, relativeDir = '', ctx) {
+    if (!ctx) ctx = synthesizeLegacyMapping();
+    const mappingId = ctx.id;
     this._processingFiles.add(filePath);
 
     try {
@@ -530,7 +617,7 @@ export class WatchFolderService {
       // Bails early if the sync root isn't configured or doesn't resolve.
       let targetCollection;
       try {
-        targetCollection = await relativePathToCollection(relativeDir, { createIfMissing: true });
+        targetCollection = await relativePathToCollection(relativeDir, { createIfMissing: true }, ctx);
       } catch (e) {
         if (e instanceof SyncRootMissingError) {
           Zotero.logError(`[WatchFolder] Sync root not found — pausing import: ${e.message}`);
@@ -553,8 +640,8 @@ export class WatchFolderService {
       // records, B2 folder-rename detection has nothing to compare
       // against on subsequent scans. (Unfiled has no path → nothing to ensure.)
       if (this._trackingStore && relativeDir !== '' && !isUnfiled) {
-        const watchPath = getPref('sourcePath') || '';
-        await this._ensureCollectionRecordsForPath(relativeDir, targetCollection, watchPath);
+        const watchPath = ctx.sourcePath || '';
+        await this._ensureCollectionRecordsForPath(relativeDir, targetCollection, watchPath, ctx);
       }
 
       // Step 3: Hash + dedup pre-check via tracking store.
@@ -574,7 +661,7 @@ export class WatchFolderService {
         const tombstone = this._trackingStore.findTombstoneByHash(hash);
         if (tombstone && tombstone.zoteroAttachmentKey && tombstone.deletedFrom === 'zotero') {
           try {
-            const syncRoot = await resolveSyncRoot().catch(() => null);
+            const syncRoot = await resolveSyncRoot(ctx).catch(() => null);
             const libraryID = syncRoot?.libraryID ?? Zotero.Libraries.userLibraryID;
             const attachment = await Zotero.Items.getByLibraryAndKeyAsync(libraryID, tombstone.zoteroAttachmentKey);
             if (attachment) {
@@ -587,9 +674,10 @@ export class WatchFolderService {
                   Zotero.debug(`[WatchFolder] Tombstone re-link: failed to un-trash ${tombstone.zoteroAttachmentKey}: ${e?.message ?? e}`);
                 }
               }
-              const watchPath = getPref('sourcePath') || '';
+              const watchPath = ctx.sourcePath || '';
               const relFile = this._toRelativeForStore(filePath, watchPath);
               this._trackingStore.add(createFileRecord({
+                mappingId,
                 localPath: relFile,
                 canonicalLocalPath: relFile,
                 lastSyncedHash: hash,
@@ -622,9 +710,10 @@ export class WatchFolderService {
                     parentItemID: parent.id,
                   });
                   if (newAttachment && newAttachment.key) {
-                    const watchPath = getPref('sourcePath') || '';
+                    const watchPath = ctx.sourcePath || '';
                     const relFile = this._toRelativeForStore(filePath, watchPath);
                     this._trackingStore.add(createFileRecord({
+                      mappingId,
                       localPath: relFile,
                       canonicalLocalPath: relFile,
                       lastSyncedHash: hash,
@@ -661,7 +750,7 @@ export class WatchFolderService {
         const existingByHash = this._trackingStore.findByHash(hash);
         if (existingByHash) {
           Zotero.debug(`[WatchFolder] File already tracked by hash: ${filePath}`);
-          const watchPath = getPref('sourcePath') || '';
+          const watchPath = ctx.sourcePath || '';
           const relFile = this._toRelativeForStore(filePath, watchPath);
           // If the existing record already represents THIS file (same
           // resolved path), skip the duplicate insert (#25 dedup).
@@ -674,6 +763,7 @@ export class WatchFolderService {
           // SAME attachment but with a different localPath. canonicalLocalPath
           // stays on the original location (canonical-path rule).
           this._trackingStore.add(createFileRecord({
+            mappingId,
             localPath: relFile,
             canonicalLocalPath: existingByHash.canonicalLocalPath,
             lastSyncedHash: hash,
@@ -753,7 +843,7 @@ export class WatchFolderService {
                   }
                 }
                 if (attachment) {
-                  const watchPath = getPref('sourcePath') || '';
+                  const watchPath = ctx.sourcePath || '';
                   const relFile = this._toRelativeForStore(filePath, watchPath);
                   // Don't double-track: if a record for this attachment
                   // at this exact path already exists, skip the insert.
@@ -763,6 +853,7 @@ export class WatchFolderService {
                     return;
                   }
                   this._trackingStore.add(createFileRecord({
+                    mappingId,
                     localPath: relFile,
                     canonicalLocalPath: relFile,
                     lastSyncedHash: hash,
@@ -813,6 +904,9 @@ export class WatchFolderService {
       // the pure `stored` strategy. `stored_plus_mirror` must keep the
       // watch-folder copy as the mirror; `linked_watch_folder` IS the
       // watch-folder file Zotero now links to — never move/delete it.
+      // PDF storage strategy is a single GLOBAL setting for all folders (v2.10),
+      // read from the `pdfStorageStrategy` pref. (Per-mapping storage was removed
+      // when the 1-folder/multi split was unified.)
       const storageStrategy = getStorageStrategy();
       if (storageStrategy === STRATEGY.STORED) {
         try {
@@ -829,9 +923,10 @@ export class WatchFolderService {
       const finalPath = postImportResult.finalPath ?? filePath;
       const wasDeleted = postImportResult.action === 'delete';
       if (this._trackingStore) {
-        const watchPath = getPref('sourcePath') || '';
+        const watchPath = ctx.sourcePath || '';
         const relFinal = this._toRelativeForStore(finalPath, watchPath);
         this._trackingStore.add(createFileRecord({
+          mappingId,
           localPath: relFinal,
           canonicalLocalPath: relFinal,
           lastSyncedHash: hash,
@@ -886,13 +981,13 @@ export class WatchFolderService {
       // Step 6: Queue for metadata retrieval if enabled.
       const autoRetrieveMetadata = getPref('autoRetrieveMetadata');
       if (autoRetrieveMetadata !== false && this._metadataRetriever) {
-        const watchPathForCallback = getPref('sourcePath') || '';
+        const watchPathForCallback = ctx.sourcePath || '';
         const finalRelKey = this._toRelativeForStore(finalPath, watchPathForCallback);
         this._metadataRetriever.queueItem(itemID, async (success, completedItemID) => {
           if (this._trackingStore) {
             // Use the sync-root-relative key matching what _processNewFile
             // just wrote (#25 migration).
-            this._trackingStore.update(finalRelKey, { metadataRetrieved: success });
+            this._trackingStore.update(finalRelKey, { metadataRetrieved: success }, mappingId);
           }
           Zotero.debug(`[WatchFolder] Metadata retrieval ${success ? 'completed' : 'failed'} for item ${completedItemID}`);
 
@@ -910,7 +1005,7 @@ export class WatchFolderService {
                 if (this._trackingStore && attachmentItem.parentItem) {
                   this._trackingStore.update(finalRelKey, {
                     zoteroItemKey: attachmentItem.parentItem.key,
-                  });
+                  }, mappingId);
                 }
                 await stampHashWhenPossible(attachmentItem);
               }
@@ -927,7 +1022,7 @@ export class WatchFolderService {
                 if (renameResult.success && renameResult.oldName !== renameResult.newName) {
                   Zotero.debug(`[WatchFolder] Renamed: "${renameResult.oldName}" → "${renameResult.newName}"`);
                   if (this._trackingStore) {
-                    this._trackingStore.update(finalRelKey, { renamed: true });
+                    this._trackingStore.update(finalRelKey, { renamed: true }, mappingId);
                   }
                 }
               }
@@ -959,7 +1054,8 @@ export class WatchFolderService {
    * @param {string} relativeDir - Forward-slash relative path, e.g. "Methods/AI".
    * @param {object} leafCollection - The Zotero.Collection at the leaf of relativeDir.
    */
-  async _ensureCollectionRecordsForPath(relativeDir, leafCollection, watchPath) {
+  async _ensureCollectionRecordsForPath(relativeDir, leafCollection, watchPath, ctx) {
+    const mappingId = ctx && ctx.id ? ctx.id : undefined;
     const segments = relativeDir.split('/').filter(s => s !== '');
     if (segments.length === 0) return;
 
@@ -992,6 +1088,7 @@ export class WatchFolderService {
         }
       }
       this._trackingStore.add(createCollectionRecord({
+        mappingId,
         localPath: relPath,
         zoteroCollectionKey: collection.key,
         parentCollectionKey: parentKey,
@@ -1041,19 +1138,22 @@ export class WatchFolderService {
    *
    * @private
    * @param {string} watchPath
+   * @param {import('./mappings.mjs').MappingContext} [ctx]
+   * @param {string[]} [precomputedDirs] - Subdir set from the caller's scanTree
+   *   walk; when provided, avoids a redundant _listSubdirectories tree walk.
    */
-  async _ensureCollectionsForExistingFolders(watchPath) {
+  async _ensureCollectionsForExistingFolders(watchPath, ctx, precomputedDirs) {
     if (!this._trackingStore || !watchPath) return;
-    const dirs = await this._listSubdirectories(watchPath);
+    if (!ctx) ctx = synthesizeLegacyMapping();
+    const dirs = precomputedDirs ?? await this._listSubdirectories(watchPath);
     if (dirs.length === 0) return;
 
     // Build the tracked-set in ABSOLUTE form for comparison with the
-    // disk `absDir`. CollectionRecord.localPath is now relative
-    // (post-#25 migration), so resolve each through _resolveTrackedAbs;
-    // legacy absolute records still match because the resolver is
-    // idempotent.
+    // disk `absDir`. Scoped to THIS mapping's collection records so another
+    // mapping's relative paths aren't resolved against the wrong watch root.
     const tracked = new Set(
       this._trackingStore.getAllOfType('collection')
+        .filter(r => (r.mappingId || LEGACY_MAPPING_ID) === ctx.id)
         .map(r => this._resolveTrackedAbs(r.localPath, watchPath)),
     );
 
@@ -1062,9 +1162,9 @@ export class WatchFolderService {
       const relDir = relativePath(absDir, watchPath);
       if (relDir == null || relDir === '') continue;
       try {
-        const col = await relativePathToCollection(relDir, { createIfMissing: true });
+        const col = await relativePathToCollection(relDir, { createIfMissing: true }, ctx);
         if (col) {
-          await this._ensureCollectionRecordsForPath(relDir, col, watchPath);
+          await this._ensureCollectionRecordsForPath(relDir, col, watchPath, ctx);
           // tracked.add(absDir) — refresh local set so subsequent siblings
           // don't double-create. _ensureCollectionRecordsForPath also
           // inserts the record into the store, so getAllOfType would
@@ -1106,10 +1206,16 @@ export class WatchFolderService {
    * @private
    * @param {Array<{path: string}>} scannedFiles
    * @param {string} watchPath
+   * @param {import('./mappings.mjs').MappingContext} [ctx]
+   * @param {string[]} [precomputedDirs] - Subdir set from the caller's scanTree
+   *   walk; when provided, avoids a redundant _listSubdirectories tree walk.
    */
-  async _detectFolderRenames(scannedFiles, watchPath) {
+  async _detectFolderRenames(scannedFiles, watchPath, ctx, precomputedDirs) {
     if (!this._trackingStore || !watchPath) return;
-    const rawRecords = this._trackingStore.getAllOfType('collection');
+    if (!ctx) ctx = synthesizeLegacyMapping();
+    // Scope to THIS mapping's collection records — another mapping's records
+    // resolve against a different watch root and must not participate here.
+    const rawRecords = this._trackingStore.getAllOfType('collection').filter(r => (r.mappingId || LEGACY_MAPPING_ID) === ctx.id);
     if (rawRecords.length === 0) return;
 
     // Normalize collection records to ABSOLUTE-path form for this
@@ -1126,7 +1232,7 @@ export class WatchFolderService {
     // Include ALL existing subdirs (even empty ones) — otherwise a tracked
     // collection record for an empty folder would be flagged as missing
     // every scan and trigger spurious "no tracked file hashes — skip" log.
-    const onDiskDirs = new Set([watchPath, ...(await this._listSubdirectories(watchPath))]);
+    const onDiskDirs = new Set([watchPath, ...(precomputedDirs ?? await this._listSubdirectories(watchPath))]);
     for (const fileInfo of scannedFiles) {
       // WP-A2 (perf): prefer the scanner-provided relativePath when present
       // (avoids recomputing from absPath + watchPath each iteration). Falls
@@ -1208,7 +1314,7 @@ export class WatchFolderService {
     // Computed once up front so the per-orphan 1:1 guard sees an accurate
     // orphan count regardless of loop order.
     const allTrackedFileAbs = this._trackingStore.getAllOfType('file')
-      .filter(f => f.lastSyncedHash)
+      .filter(f => f.lastSyncedHash && (f.mappingId || LEGACY_MAPPING_ID) === ctx.id)
       .map(f => this._resolveTrackedAbs(f.localPath, watchPath));
     const missingHasTrackedFiles = (absPath) => {
       const prefix = absPath + '/';
@@ -1253,7 +1359,7 @@ export class WatchFolderService {
       // Re-fetch tracked files each iteration — earlier rename sweeps may
       // have rewritten paths. Resolve each file's localPath to absolute
       // for comparison (post-#25 records are sync-root-relative).
-      const trackedFilesNow = this._trackingStore.getAllOfType('file');
+      const trackedFilesNow = this._trackingStore.getAllOfType('file').filter(f => (f.mappingId || LEGACY_MAPPING_ID) === ctx.id);
       const trackedShape = new Map(); // hash → tail under oldPath
       for (const f of trackedFilesNow) {
         if (!f.lastSyncedHash) continue;
@@ -1276,7 +1382,7 @@ export class WatchFolderService {
             && orphans[0].zoteroCollectionKey === collRecord.zoteroCollectionKey) {
           const target = newEmpties[0];
           Zotero.debug(`[WatchFolder] Empty-folder rename detected (1:1): ${oldPath} → ${target}`);
-          await this._renameTrackedCollection(collRecord, target);
+          await this._renameTrackedCollection(collRecord, target, ctx);
         } else {
           Zotero.debug(`[WatchFolder] Folder ${oldPath} missing but no tracked file hashes under it — skip (empty-folder match ambiguous: ${orphans.length} orphan(s), ${newEmpties.length} new empty dir(s))`);
         }
@@ -1285,6 +1391,7 @@ export class WatchFolderService {
 
       const trackedDirs = new Set(
         this._trackingStore.getAllOfType('collection')
+          .filter(r => (r.mappingId || LEGACY_MAPPING_ID) === ctx.id)
           .map(r => this._resolveTrackedAbs(r.localPath, watchPath)),
       );
       const candidateDirs = [...onDiskDirs].filter(d =>
@@ -1312,7 +1419,7 @@ export class WatchFolderService {
 
       if (best && bestScore >= 1) {
         Zotero.debug(`[WatchFolder] Folder rename detected: ${oldPath} → ${best} (matched files=${bestScore})`);
-        await this._renameTrackedCollection(collRecord, best);
+        await this._renameTrackedCollection(collRecord, best, ctx);
       }
     }
 
@@ -1326,18 +1433,19 @@ export class WatchFolderService {
    *
    * @private
    */
-  async _renameTrackedCollection(oldRecord, newPath) {
+  async _renameTrackedCollection(oldRecord, newPath, ctx) {
     // oldRecord may carry _absLocalPath (set by _detectFolderRenames'
     // normalization pass) or raw localPath that's relative or absolute.
     // newPath is the new absolute disk path of the renamed dir.
-    const watchPath = getPref('sourcePath') || '';
+    if (!ctx) ctx = synthesizeLegacyMapping();
+    const watchPath = ctx.sourcePath || '';
     const oldAbs = oldRecord._absLocalPath
       ?? this._resolveTrackedAbs(oldRecord.localPath, watchPath);
     const newAbs = newPath;
     const newRel = this._toRelativeForStore(newAbs, watchPath);
     const newName = newPath.split('/').pop();
     try {
-      const syncRoot = await resolveSyncRoot().catch(() => null);
+      const syncRoot = await resolveSyncRoot(ctx).catch(() => null);
       const libraryID = syncRoot?.libraryID ?? Zotero.Libraries.userLibraryID;
       const collection = await Zotero.Collections.getByLibraryAndKeyAsync(
         libraryID, oldRecord.zoteroCollectionKey);
@@ -1367,7 +1475,7 @@ export class WatchFolderService {
     const oldPrefix = oldAbs + '/';
     const newPrefix = newAbs + '/';
 
-    const files = this._trackingStore.getAllOfType('file').slice();
+    const files = this._trackingStore.getAllOfType('file').slice().filter(f => (f.mappingId || LEGACY_MAPPING_ID) === ctx.id);
     for (const f of files) {
       const fAbs = this._resolveTrackedAbs(f.localPath, watchPath);
       let newLocalAbs = null;
@@ -1376,11 +1484,11 @@ export class WatchFolderService {
       else continue;
       const newLocalRel = this._toRelativeForStore(newLocalAbs, watchPath);
       const updated = { ...f, localPath: newLocalRel, canonicalLocalPath: newLocalRel };
-      this._trackingStore.remove(f.localPath);
+      this._trackingStore.remove(f.localPath, f.mappingId);
       this._trackingStore.add(updated);
     }
 
-    const cols = this._trackingStore.getAllOfType('collection').slice();
+    const cols = this._trackingStore.getAllOfType('collection').slice().filter(c => (c.mappingId || LEGACY_MAPPING_ID) === ctx.id);
     for (const c of cols) {
       if (c.zoteroCollectionKey === oldRecord.zoteroCollectionKey) continue; // already handled
       const cAbs = this._resolveTrackedAbs(c.localPath, watchPath);
@@ -1556,7 +1664,7 @@ export class WatchFolderService {
         case 'trash': {
           // Mode 1 never propagates Zotero deletions back to disk.
           // v2.1 / v2.2 reactivate this path with explicit safety nets.
-          const mode = getPref('mode') || 'mode1';
+          const mode = isMultiMappingActive() ? 'mode1' : (getPref('mode') || 'mode1');
           if (mode === 'mode1') {
             Zotero.debug(`[WatchFolder] Mode 1: ignoring trash event for items ${ids.join(', ')}`);
             break;
@@ -1572,7 +1680,7 @@ export class WatchFolderService {
           // file from plugin trash if available. Zotero's notifier
           // fires 'modify' for trash + untrash both — distinguish via
           // the current `deleted` state and the tombstone presence.
-          const mode = getPref('mode') || 'mode1';
+          const mode = isMultiMappingActive() ? 'mode1' : (getPref('mode') || 'mode1');
           if (mode === 'mode1') break;
           if (!this._trackingStore) break;
           // Cheap pre-filter: only do restore work when we actually
@@ -1619,7 +1727,7 @@ export class WatchFolderService {
    */
   async _handleZoteroTrash(ids) {
     if (!this._trackingStore || !ids || ids.length === 0) return;
-    const syncMode = getPref('mode') || 'mode1';
+    const syncMode = isMultiMappingActive() ? 'mode1' : (getPref('mode') || 'mode1');
     if (syncMode === 'mode1') return; // defense in depth
 
     const watchPath = getPref('sourcePath') || '';
@@ -2259,25 +2367,27 @@ export class WatchFolderService {
    *
    * @param {Set<string>} diskPaths - Paths currently present in the watch folder
    */
-  async _handleExternalDeletions(diskPaths, allFiles = null) {
+  async _handleExternalDeletions(diskPaths, allFiles = null, ctx) {
     if (!this._trackingStore) return;
+    if (!ctx) ctx = synthesizeLegacyMapping();
     // `diskDeleteSync`: 'never' → never propagate (early-out); 'auto' → silently
     // trash; 'ask' (default) → prompt before touching Zotero (resolved below,
     // once we know the affected file list).
     if ((getPref('diskDeleteSync') || 'ask') === 'never') return;
 
-    // Whole-mount sanity check: if the watch root itself is unreachable
+    // Whole-mount sanity check: if THIS mapping's watch root is unreachable
     // (USB unplugged, network share gone, cloud client logged out), every
-    // tracked file would naively look "missing". Pause sync globally
-    // instead of mass-tagging.
-    const watchPath = getPref('sourcePath') || '';
+    // tracked file under it would naively look "missing". Pause just this
+    // mapping's records instead of mass-tagging.
+    const watchPath = ctx.sourcePath || '';
     if (watchPath) {
       const rootAvailable = await isWatchRootAvailable(watchPath);
       if (!rootAvailable) {
-        Zotero.debug('[WatchFolder] Watch root unavailable — pausing external-deletion scan');
+        Zotero.debug(`[WatchFolder] Watch root unavailable (mapping ${ctx.id}) — pausing external-deletion scan`);
         for (const r of this._trackingStore.getAllOfType('file')) {
+          if ((r.mappingId || LEGACY_MAPPING_ID) !== ctx.id) continue;
           if (r.state !== STATE.PAUSED) {
-            this._trackingStore.update(r.localPath, { state: STATE.PAUSED });
+            this._trackingStore.update(r.localPath, { state: STATE.PAUSED }, ctx.id);
           }
         }
         try { await this._trackingStore.save(); } catch (_) {}
@@ -2285,9 +2395,10 @@ export class WatchFolderService {
       }
     }
 
-    // v2 schema: enumerate FILE records only (collection + tombstone
-    // records have their own paths and are handled elsewhere).
-    const records = this._trackingStore.getAllOfType('file');
+    // v2 schema: enumerate FILE records for THIS mapping only (a per-mapping
+    // scan's diskPaths only contains this mapping's files — treating another
+    // mapping's records as "missing" here would be a cross-mapping deletion).
+    const records = this._trackingStore.getAllOfType('file').filter(r => (r.mappingId || LEGACY_MAPPING_ID) === ctx.id);
     const missing = [];
 
     for (const record of records) {
@@ -2372,7 +2483,7 @@ export class WatchFolderService {
 
     if (moves.length > 0) {
       Zotero.debug(`[WatchFolder] Detected ${moves.length} file move(s)`);
-      await this._handleFileMoves(moves);
+      await this._handleFileMoves(moves, ctx);
     }
 
     if (trulyMissing.length === 0) return;
@@ -2391,7 +2502,7 @@ export class WatchFolderService {
           || classification === MISSING_CLASSIFICATION.CLOUD_PLACEHOLDER) {
         const newState = STATE_FOR_CLASSIFICATION[classification];
         if (record.state !== newState) {
-          this._trackingStore.update(record.localPath, { state: newState });
+          this._trackingStore.update(record.localPath, { state: newState }, ctx.id);
         }
         continue;
       }
@@ -2412,10 +2523,10 @@ export class WatchFolderService {
     // a warningSink entry so the user sees the event (bug #33 fix —
     // previously the Mode-3 modal alert fired in Mode 2 too, blocking
     // the bridge and creating modal popups for every deleted file).
-    const mode = getPref('mode') || 'mode1';
+    const mode = this._effectiveMode(ctx);
     if (mode !== 'mode3') {
       for (const record of stillMissing) {
-        this._trackingStore.update(record.localPath, { state: STATE.MISSING });
+        this._trackingStore.update(record.localPath, { state: STATE.MISSING }, ctx.id);
         if (mode === 'mode2') {
           try {
             reportWarning({
@@ -2441,9 +2552,9 @@ export class WatchFolderService {
     // blast-radius acknowledgement before propagating ANY external deletion to
     // Zotero. Fail-closed (no UI → refuse). Below it, the per-batch bulk prompt
     // only fires above the threshold, so this covers single/sub-threshold cases.
-    if (stillMissing.length > 0 && !(await confirmFirstLibraryDelete({ scopeMode: getScopeMode() }))) {
+    if (stillMissing.length > 0 && !(await confirmFirstLibraryDelete({ scopeMode: getScopeMode(ctx) }))) {
       for (const record of stillMissing) {
-        this._trackingStore.update(record.localPath, { state: STATE.MISSING });
+        this._trackingStore.update(record.localPath, { state: STATE.MISSING }, ctx.id);
       }
       try { await this._trackingStore.save(); } catch (_) {}
       Zotero.debug(`[WatchFolder] _handleExternalDeletions: ${stillMissing.length} propagation(s) blocked — library-scale deletion not acknowledged; marked missing instead`);
@@ -2465,7 +2576,7 @@ export class WatchFolderService {
       userConfirmed = true;
       if (choice === 'keep') {
         for (const record of stillMissing) {
-          this._trackingStore.update(record.localPath, { state: STATE.MISSING });
+          this._trackingStore.update(record.localPath, { state: STATE.MISSING }, ctx.id);
         }
         try { await this._trackingStore.save(); } catch (_) {}
         Zotero.debug(`[WatchFolder] _handleExternalDeletions: user chose KEEP for ${stillMissing.length} deleted file(s) — Zotero items untouched, marked missing`);
@@ -2496,7 +2607,7 @@ export class WatchFolderService {
           // tracking flips to MISSING so we don't re-detect, but the
           // Zotero side stays intact and the user can resolve manually.
           for (const record of stillMissing) {
-            this._trackingStore.update(record.localPath, { state: STATE.MISSING });
+            this._trackingStore.update(record.localPath, { state: STATE.MISSING }, ctx.id);
             try {
               reportWarning({
                 category: WARNING_CATEGORY.MISSING_FILE,
@@ -2536,13 +2647,13 @@ export class WatchFolderService {
           const canonExists = await IOUtils.exists(canonAbs).catch(() => false);
           if (canonExists) {
             Zotero.debug(`[WatchFolder] Cascading-trash guard: shadow ${record.localPath} missing but canonical ${canonical.localPath} still on disk — dropping shadow only`);
-            this._trackingStore.remove(record.localPath);
+            this._trackingStore.remove(record.localPath, ctx.id);
             continue;
           }
         }
       }
       try {
-        const syncRoot = await resolveSyncRoot().catch(() => null);
+        const syncRoot = await resolveSyncRoot(ctx).catch(() => null);
         const libraryID = syncRoot?.libraryID ?? Zotero.Libraries.userLibraryID;
         const item = await Zotero.Items.getByLibraryAndKeyAsync(libraryID, record.zoteroAttachmentKey);
         if (!item) {
@@ -2557,7 +2668,7 @@ export class WatchFolderService {
         // last saw. The record is kept (CONFLICT_BLOCKED) for user resolution.
         const fresh = await canSafelyTrashZoteroAttachment(record, item);
         if (!fresh.ok) {
-          this._trackingStore.update(record.localPath, { state: STATE.CONFLICT_BLOCKED });
+          this._trackingStore.update(record.localPath, { state: STATE.CONFLICT_BLOCKED }, ctx.id);
           try {
             reportWarning({
               category: WARNING_CATEGORY.CONFLICT_BLOCKED,
@@ -2732,9 +2843,10 @@ export class WatchFolderService {
    *
    * @param {{record: TrackingRecord, newPath: string}[]} moves
    */
-  async _handleFileMoves(moves) {
+  async _handleFileMoves(moves, ctx) {
     if (!moves || moves.length === 0) return;
-    const watchPath = getPref('sourcePath') || '';
+    if (!ctx) ctx = synthesizeLegacyMapping();
+    const watchPath = ctx.sourcePath || '';
 
     // Helper: compute the sync-root-relative directory for a file path.
     // Returns "" if the file is at the watch-folder root.
@@ -2753,14 +2865,14 @@ export class WatchFolderService {
       Zotero.debug(`[WatchFolder] Move: relativeDir "${oldRel}" → "${newRel}"`);
 
       try {
-        const syncRoot = await resolveSyncRoot().catch(() => null);
+        const syncRoot = await resolveSyncRoot(ctx).catch(() => null);
         const libraryID = syncRoot?.libraryID ?? Zotero.Libraries.userLibraryID;
         const item = await Zotero.Items.getByLibraryAndKeyAsync(libraryID, record.zoteroAttachmentKey);
 
         if (item && !item.deleted) {
           if (oldRel !== newRel && newRel != null) {
             // Resolve / create the new auto-mapped collection under the sync root.
-            const newCollection = await relativePathToCollection(newRel, { createIfMissing: true });
+            const newCollection = await relativePathToCollection(newRel, { createIfMissing: true }, ctx);
             // Library scope: a move UP TO THE ROOT yields newRel '' →
             // relativePathToCollection returns the truthy UNFILED sentinel (no
             // .id/.key). That means "make the item Unfiled": drop the old
@@ -2771,7 +2883,7 @@ export class WatchFolderService {
               // Remove from the OLD auto-mapped collection if currently a
               // member; preserve manually-added collection memberships.
               const oldCollection = (oldRel != null)
-                ? await relativePathToCollection(oldRel, { createIfMissing: false }).catch(() => null)
+                ? await relativePathToCollection(oldRel, { createIfMissing: false }, ctx).catch(() => null)
                 : null;
               const currentColIDs = item.getCollections ? item.getCollections() : [];
               if (oldCollection && oldCollection !== UNFILED && currentColIDs.includes(oldCollection.id)) {
@@ -2796,7 +2908,7 @@ export class WatchFolderService {
         if (newRel == null) {
           newCanonicalCollectionKey = record.canonicalCollectionKey;
         } else {
-          const resolved = await relativePathToCollection(newRel, { createIfMissing: false }).catch(() => null);
+          const resolved = await relativePathToCollection(newRel, { createIfMissing: false }, ctx).catch(() => null);
           // Library scope: UNFILED (move to root) → canonical key is null
           // (Unfiled), NOT a fallback to the stale old key. null/unresolved with
           // a non-root path → keep the prior key (transient resolve miss).
@@ -2807,7 +2919,7 @@ export class WatchFolderService {
           }
         }
         const newRelLocal = this._toRelativeForStore(newPath, watchPath);
-        this._trackingStore.remove(record.localPath);
+        this._trackingStore.remove(record.localPath, ctx.id);
         this._trackingStore.add(createFileRecord({
           ...record,
           localPath: newRelLocal,

--- a/docs/mode2-mode3-design.md
+++ b/docs/mode2-mode3-design.md
@@ -1,0 +1,281 @@
+# Design: Sync Mode 2 & Mode 3 for the folder-list model
+
+Status: **PROPOSED** (not yet implemented) · Target: v3.1 (Mode 2) → v3.2 (Mode 3)
+Author: fork maintainer · Date: 2026-07-25
+
+## 1. Goal
+
+Re-enable the two mirror modes so they work in the current **always-multi folder-list
+model**, applied **globally to all watch folders** (one shared mode — the user's
+"same for all folders").
+
+| Mode | Name | Direction & effect | Deletes? |
+|------|------|--------------------|----------|
+| `mode1` | Import only (current, default) | disk → Zotero, import PDFs | never |
+| `mode2` | Mirror without delete | disk ↔ Zotero: collection renames/moves + item moves reflected both ways; **all deletions are warn-only** | never |
+| `mode3` | Mirror with safe delete | mode2 **plus** propagate deletions (folder→trash-collection, disk-delete→trash-attachment) behind fail-closed gates | yes, gated |
+
+**Non-goals.** No per-folder mode (the `mode` pref stays global; per-mapping `mode`
+field stays inert). No change to import-only behavior or its defaults. No new sync
+directions beyond what single-root Mode 2/3 already did.
+
+## 2. Core principle: global policy, per-mapping routing
+
+The single hardest fact about this change:
+
+> **Mode (policy) is global. Scope (routing) is per-mapping.**
+
+- **Policy is trivial to make global:** "do we mirror? do we delete?" is one pref read.
+- **Routing is the real work:** there are now *N* watch roots on disk and *N* target
+  collections in Zotero. Every event — a collection renamed in Zotero, a folder deleted
+  on disk, an item added to a collection — must be attributed to **exactly one owning
+  mapping** so it uses that mapping's watch root and sync-root. Get this wrong and an
+  edit in folder A fans out into folder B's tree (Mode 2) or deletes from it (Mode 3).
+
+Most of the *data* layer is already per-mapping (see §3). The gap is the *event* layer:
+the notifier observers and the mirror executor still resolve a single global watch
+root / sync root.
+
+## 3. Current state (verified against code)
+
+### Already per-mapping ready — reuse as-is
+- **trackingStore** — records carry `mappingId`; composite key `mappingId\0localPath`.
+- **canonicalPath** — every `collectionKeyTo*` resolver takes an optional `ctx`.
+- **baseline** (`content/baseline.mjs`) — `runBaseline({mapping})` threads `ctx`;
+  per-mapping completion pref `baselineCompletedByMapping` already exists
+  (`baseline.mjs:61-99`).
+- **reconcile** (`content/reconcile.mjs`) — `_detectMulti` loops `getActiveMappings()`;
+  findings carry `mappingId`; `applyRepairs` routes per finding.
+- **Per-file delete gates** — `canSafelyMove(record, absPath)` /
+  `canSafelyTrashZoteroAttachment(record, item)` (`mirrorExecutor.mjs:192-288`) are
+  pure per-record functions; they recompute SHA-256 **directly** (never via the mtime
+  cache) so a mtime-preserving overwrite can't fail them open. Records carry `mappingId`,
+  so scoping is the caller's job — already satisfied.
+- **The scan loop** — `_scan()` already loops `getActiveMappings()` → `_scanMapping(ctx)`
+  (`watchFolder.mjs:364-433`); every tracking mutation inside is `ctx`-scoped.
+
+### Single-root only — must be made per-mapping
+- **`_effectiveMode(ctx)`** (`watchFolder.mjs:117-120`): `if (isMultiMappingActive()) return 'mode1';`
+  — the blanket force-off. Also note the fallback `return (ctx && ctx.mode) || getPref('mode')…`
+  prefers the (always-`'mode1'`) inert `ctx.mode`; once un-forced it must read the
+  **global** pref, ignoring `ctx.mode`, to honor "same for all folders".
+- **`syncCoordinator.start()`** (`syncCoordinator.mjs:110`):
+  `const mode = isMultiMappingActive() ? 'mode1' : (getPref('mode')…)` — coordinator
+  stays idle in multi. Must read the global mode and wire the observers.
+- **`mirrorExecutor._watchRoot()`** (`mirrorExecutor.mjs:292-296`): returns
+  `getPref('sourcePath')`. **Hard blocker** — every fs mutation resolves one global root.
+  Must resolve from the action's owning mapping.
+- **`collectionWatcher`** (`collectionWatcher.mjs`): one global `Zotero.Notifier`
+  observer (`:154`); scope resolution via global `getPref('sourcePath')` (`:405`) and
+  `collectionKeyToDiskRelativePath(key)` **without** ctx (`:288`). Must route each event
+  to its owning mapping.
+- **`folderEventDetector.detectFolderEvents()`** (`folderEventDetector.mjs:50-87`):
+  enumerates **all** `collection` records globally. Must run per-mapping (filter records
+  by `mappingId`, use `ctx.sourcePath` as the root).
+- **`itemMembershipHandler`** (`itemMembershipHandler.mjs`): `resolveSyncRoot()` /
+  `collectionKeyToDiskRelativePath()` called without ctx (`:62,96,223,245,338`). Must
+  resolve the owning mapping per event.
+- **`watchRootGuard`** (`watchRootGuard.mjs`): the SYNC-1 collapse fingerprint is a
+  **single global pref** `watchRootTopLevelFingerprint` (`:83,99`). Must be per-mapping,
+  else one folder's cloud-eviction blocks/aliases another's.
+- **`bulkGuard.confirmFirstLibraryDelete()`** (`bulkGuard.mjs:151`): one-time ack via
+  global `mode3LibraryDeleteAcknowledged`. A per-mapping pref `mode3AckByMapping` is
+  already scaffolded in `bootstrap.js` — switch to it.
+- **`validateMapping`** (`mappings.mjs:196`): rejects overlapping **disk paths** only.
+  Does **not** reject overlapping **target collections**. Harmless for import-only;
+  a routing hazard for mirroring (see §4).
+
+## 4. New risks unique to multi-folder mirroring
+
+These do not exist in single-root Mode 2/3 and must be designed for:
+
+1. **Cross-mapping contamination.** An item can live in collections belonging to
+   different mappings; a collection can be dragged from one mapping's subtree into
+   another's. The canonical-path rule and every mirror action must be scoped to one
+   owning mapping and must **refuse to act** when ownership is ambiguous (fail-closed).
+
+2. **Overlapping / nested target collections.** Mapping A → "Papers", Mapping B →
+   "Papers/Draft". **Resolution (decision: auto-pick):** the **nearest sync-root ancestor
+   wins** — walk a collection's ancestor chain, and the first mapping sync-root you hit
+   owns it. So B owns "Papers/Draft" and its subtree; A owns the rest of "Papers". This is
+   deterministic (no runtime coin-flip). Nesting is **allowed**; only two mappings whose
+   sync-roots are the *exact same collection* is a genuine tie with no winner — that stays
+   a hard `validateMapping` reject (it's also meaningless for imports).
+
+3. **Library-scope collisions.** A whole-library mapping plus a collection-scope mapping
+   in the *same* library. **Resolution:** same nearest-ancestor rule — the collection-scope
+   mapping owns its subtree, the library-scope mapping owns everything else in the library
+   (it's the fallback owner when no collection sync-root is an ancestor). Allowed; the only
+   reject is two library-scope mappings on the *same* library (exact tie).
+
+4. **Shared guard state.** The collapse fingerprint and the first-delete ack were global.
+   Per-mapping slots are required so a benign event in one folder can't unlock or block a
+   destructive path in another.
+
+5. **Bulk-delete accounting.** "> 20% of tracked files" must be computed **per mapping**
+   (a 200-file folder shouldn't dilute a 3-file folder's collapse) **and** an aggregate
+   absolute cap (`>200` across the cycle) still applies. Keep both.
+
+## 5. The owning-mapping resolver (new, shared)
+
+A single new helper is the backbone of Stage A. Add to `content/mappings.mjs` (or a new
+`content/mappingRouter.mjs`):
+
+```
+mappingForCollection(collection) -> ctx | null
+  // NEAREST SYNC-ROOT ANCESTOR WINS (deterministic auto-pick).
+  // Walk the collection's ancestor chain from the collection upward:
+  //   - the first mapping whose collection-scope syncRoot == a node on that chain owns it;
+  //   - if none, and a library-scope mapping covers collection.libraryID, that mapping owns it;
+  //   - else null (this collection belongs to no watch folder — skip).
+
+mappingForItem(item) -> ctx | null
+  // The item's canonical collection (chosen by the existing canonical-path rule,
+  // scoped to a single mapping's subtree) -> mappingForCollection. One owner by
+  // construction of the nearest-ancestor rule; no runtime ambiguity.
+```
+
+Because ownership is decided by *nearest ancestor*, there is never a runtime tie: every
+collection has at most one closest sync-root above it. The exact-duplicate sync-root case
+(the only true tie) is eliminated at config time by `validateMapping` (§4.2/4.3), so the
+resolver never has to guess.
+
+## 6. Stage A — Mode 2 (mirror, NO delete)
+
+**Safety envelope:** Mode 2 never deletes. The worst possible failure is a stray folder
+or a suppressed tracking record — recoverable, no data loss. This is why it ships first
+and does **not** require the full adversarial gate review that Stage B does.
+
+### A1. Un-force the mode (read the global pref)
+- `watchFolder.mjs` `_effectiveMode(ctx)`: drop the `isMultiMappingActive()` short-circuit;
+  return `getPref('mode') || 'mode1'` (ignore inert `ctx.mode`).
+- `syncCoordinator.mjs` `start()` / `_onModeChanged()`: read `getPref('mode')`; when the
+  global mode is `mode2`/`mode3`, wire the observers.
+
+### A2. Owning-mapping routing (§5) wired into the event layer
+- **mirrorExecutor:** every action payload gains `mappingId`; `_watchRoot(action)`
+  resolves the root from `getMappingById(action.mappingId)` (fall back to legacy synth for
+  single-root installs). No action executes without a resolved owner.
+- **collectionWatcher:** on each collection / collection-item event, call
+  `mappingForCollection`; skip events with no owner; thread `ctx` into
+  `collectionKeyToDiskRelativePath(key, ctx)` and stamp `mappingId` on emitted actions.
+  (The one global observer stays — routing happens inside the handler; do not register N
+  observers.)
+- **folderEventDetector:** call once per mapping from the scan loop — filter
+  `getAllOfType('collection')` by `mappingId`, use `ctx.sourcePath` as `watchRoot`.
+- **itemMembershipHandler:** resolve owner per event via `mappingForItem`; thread `ctx`
+  through all `resolveSyncRoot`/`collectionKeyTo*` calls; scope the canonical-collection
+  choice to the owning mapping's subtree only.
+
+### A3. Per-mapping baseline on activation
+- On first transition to `mode ≥ 2`, run `baseline.runBaseline({mapping: ctx})` for each
+  active mapping (already ctx-ready; completion tracked in `baselineCompletedByMapping`).
+  Baseline is additive (copies attachments to canonical disk paths, mkdirs empty
+  subcollections) — no deletes.
+
+### A4. Config validation (§4.2, §4.3)
+- Extend `validateMapping` to reject only the genuine tie: a new mapping whose sync-root
+  is the **exact same** collection as an existing mapping's, or a second **library-scope**
+  mapping on a library that already has one. Nesting/overlap is **allowed** — the
+  nearest-ancestor resolver (§5) picks the owner deterministically at runtime.
+
+### A5. UI
+- `preferences.xhtml`: enable the **mode2** card — remove `disabled="true"`,
+  `opacity:0.5`, the "Coming soon" badge; restore `onclick="…changeMode('mode2')"`.
+  Leave **mode3** disabled until Stage B. `changeMode` already handles mode2 end-to-end.
+
+### A6. Tests (Stage A)
+- New `mappingRouter` unit tests: owner resolution, ancestor match, library scope,
+  **ambiguity → null**.
+- `validateMapping` target-overlap + library-collision cases.
+- Multi-mapping Mode 2 integration: rename collection in A → folder renamed under A's
+  root only; item moved in A → not reflected in B; folder deleted on disk under A →
+  **warn-only**, record `OUT_OF_SCOPE_SUPPRESSED`, nothing deleted, B untouched.
+- Cross-mapping isolation assertions on every action type.
+- Adjust existing single-root Mode 2 tests only where the executor payload gains
+  `mappingId` (default to `legacy`).
+
+## 7. Stage B — Mode 3 (mirror + safe delete)
+
+**This stage deletes files and trashes Zotero items.** It ships only after the
+adversarial multi-agent review mandated by CLAUDE.md (find → verify → synthesize).
+
+### B1. Per-mapping guard state
+- **Collapse fingerprint:** replace the global `watchRootTopLevelFingerprint` with a
+  per-mapping map (`watchRootFingerprintByMapping`, mirroring the
+  `baselineCompletedByMapping` pattern). `checkTopLevelCollapse` keyed by `mappingId`.
+- **First-library-delete ack:** switch `confirmFirstLibraryDelete` to `mode3AckByMapping`
+  (already scaffolded in bootstrap). One ack per library-scope mapping.
+
+### B2. Delete arms (already exist in mirrorExecutor — re-scope, don't rewrite)
+- `_zoteroCollectionDeleted` (`:551`) and `_localFolderDeleted` (`:804`) already implement
+  the mode2-suppress vs mode3-delete branches. Route them through the owning mapping's
+  root/sync-root and per-mapping guard state. Every attachment trash stays behind
+  `canSafelyTrashZoteroAttachment`; every local move behind `canSafelyMove`.
+
+### B3. Bulk accounting (§4.5)
+- `bulkGuard.isBulkDelete` computed **per mapping** (affected vs that mapping's tracked
+  count) **and** an aggregate absolute cap per scan cycle. Confirmation modal names the
+  affected folder.
+
+### B4. UI
+- Enable the **mode3** card; the Mode-3-only deletion-disposition group
+  (`refreshDeletionUI`) and external-deletion group (`refreshExtDelUI`) already gate on
+  `mode === 'mode3'`.
+
+### B5. Adversarial review (gate to ship)
+Multi-agent find → verify → synthesize focused on: fail-open holes in the re-scoped
+delete paths; cross-mapping deletion leakage; ambiguity handling; collapse-guard bypass;
+ack-state confusion; ordering (baseline vs delete) races. Only CONFIRMED-safe ships.
+
+### B6. Tests (Stage B)
+- Per-mapping collapse fingerprint (eviction in A pauses A only, never B).
+- Per-mapping first-delete ack.
+- Cross-mapping deletion isolation: mode3 delete in A never trashes B's items/files.
+- Hash-drift refusal on trash/move (fail-closed) per mapping.
+- Bulk threshold per mapping + aggregate cap.
+
+## 8. Prefs summary
+
+| Pref | Change |
+|------|--------|
+| `mode` | unchanged (global; now honored in multi) |
+| `watchRootFingerprintByMapping` | **new** JSON map, replaces global fingerprint for multi |
+| `mode3AckByMapping` | **use** (already scaffolded) instead of `mode3LibraryDeleteAcknowledged` |
+| `baselineCompletedByMapping` | already used |
+| per-mapping `mode` / `pdfStorageStrategy` | stay **inert** (global wins) |
+
+No net new user-facing prefs; the additions are internal state maps.
+
+## 9. Build / release
+
+**Decision: build both, release together as a single version (v3.1.0).** The *internal*
+build is still staged for tractability and safety — Mode 2 implemented and fully green
+first, then Mode 3 layered on top — but there is one published artifact.
+
+- Implement Stage A (Mode 2), suite green, bundle clean.
+- Implement Stage B (Mode 3) on top, suite green, bundle clean.
+- **Adversarial delete-review (§B5) gates the release** — nothing publishes until Mode 3's
+  re-scoped delete paths are CONFIRMED safe. (This satisfies CLAUDE.md's "review before
+  shipping delete-capable code": the review is about what gets *published*, and the
+  combined artifact contains delete code.)
+- Trial `.xpi` → archive to `xpi-builds/` → live-verify Mode 2 mirroring *and* Mode 3
+  deletes on a throwaway library → release **v3.1.0** (both cards enabled).
+- Suite stays green (currently 1011 / 29 files); esbuild bundle clean before packaging.
+
+## 10. Rollback / safety posture
+
+- Setting `mode` back to `mode1` instantly returns to import-only (the scan loop and
+  `_effectiveMode` read it live) — no data migration to undo.
+- Mode 2 is non-destructive by construction. Mode 3's every delete passes a per-record
+  direct-hash gate + bulk guard + per-mapping collapse guard + first-delete ack; any gate
+  failing → suppress-not-delete (fail-closed), matching the single-root contract.
+
+## 11. Decisions (resolved 2026-07-25)
+
+1. **Bulk thresholds:** per-mapping **plus** an aggregate absolute cap per scan cycle.
+2. **Overlapping targets:** **auto-pick via nearest-ancestor** — nesting allowed, resolved
+   deterministically at runtime; only exact-duplicate / double-library-scope sync-roots are
+   rejected at config time (§4.2/4.3, §5).
+3. **Release:** build both modes, **release together as v3.1.0**; the adversarial delete
+   review still gates the combined release (§9).

--- a/test/unit/canonicalPath.test.mjs
+++ b/test/unit/canonicalPath.test.mjs
@@ -367,6 +367,20 @@ describe('UT-205: chooseCanonicalCollection', () => {
     const c = await chooseCanonicalCollection(item, root);
     expect(c.key).toBe('METHODS'); // virt is filtered out
   });
+
+  it('collection-mode candidacy is scoped by ctx, not the global sync root (regression: ctx threading through line-609)', async () => {
+    // Global sync root = ROOT1 (beforeEach). A per-mapping ctx whose sync root is
+    // the NESTED METHODS collection must judge candidacy against METHODS — an
+    // item's canonical must be chosen from the OWNING folder's scope, never the
+    // global one. Item is in DEEP (under METHODS) and IMPORTANT (under ROOT1 but
+    // NOT under METHODS). Pre-fix, IMPORTANT leaked in via the global scope and
+    // won rule-4 shortest-path; with ctx threaded, only DEEP qualifies.
+    const ctxB = { scopeMode: 'collection', syncRootCollectionKey: 'METHODS', syncRootLibraryID: 1 };
+    const methods = collections.find((c) => c.key === 'METHODS');
+    const item = makeItem([4, 3]); // DEEP + IMPORTANT
+    const c = await chooseCanonicalCollection(item, methods, {}, ctxB);
+    expect(c && c.key).toBe('DEEP');
+  });
 });
 
 // ─── UT-206 — path-traversal defense (security audit 2026-05-27) ──────────

--- a/test/unit/collectionWatcher.test.mjs
+++ b/test/unit/collectionWatcher.test.mjs
@@ -512,3 +512,66 @@ describe('UT-311: notifier debounce + coalescing (WP-C #4)', () => {
     expect(mirrorExecutor.execute.mock.calls[0][0].type).toBe('createFolder');
   });
 });
+
+// ─── UT-310: multi-mapping routing + cross-mapping isolation ─────────────────
+//
+// With the folder-list model active (watchMappingsMulti), each collection event
+// must be attributed to its OWNING watch folder (nearest-ancestor), the emitted
+// action stamped with that mapping's id, and events on collections no folder
+// owns dropped. Uses the real mappings + mappingRouter (not mocked here).
+
+describe('UT-310: multi-mapping routing', () => {
+  const ROOT_A = { id: 100, key: 'ROOTA', name: 'InboxA', libraryID: 1, parentID: null };
+  const SUB_A = { id: 200, key: 'SUBA', name: 'MethodsA', libraryID: 1, parentID: 100 };
+  const ROOT_B = { id: 101, key: 'ROOTB', name: 'InboxB', libraryID: 1, parentID: null };
+  const SUB_B = { id: 201, key: 'SUBB', name: 'MethodsB', libraryID: 1, parentID: 101 };
+  const ORPHAN = { id: 300, key: 'ORPH', name: 'Orphan', libraryID: 1, parentID: null };
+
+  const MAPPINGS = [
+    { id: 'mapa', sourcePath: '/watch/A', scopeMode: 'collection', syncRootCollectionKey: 'ROOTA', syncRootLibraryID: 1, mode: 'mode2', pdfStorageStrategy: 'stored' },
+    { id: 'mapb', sourcePath: '/watch/B', scopeMode: 'collection', syncRootCollectionKey: 'ROOTB', syncRootLibraryID: 1, mode: 'mode2', pdfStorageStrategy: 'stored' },
+  ];
+
+  function multiPrefs() {
+    prefStubs({ watchMappingsMulti: true, watchMappings: JSON.stringify(MAPPINGS) });
+  }
+
+  it('stamps the owning mappingId on the emitted action (folder A → mapa)', async () => {
+    makeCollectionRegistry([ROOT_A, SUB_A, ROOT_B, SUB_B, ORPHAN]);
+    multiPrefs();
+    const getObs = captureObserverID();
+    start(makeCoordinator(makeStore()));
+
+    await getObs().notify('add', 'collection', [SUB_A.id], {});
+
+    expect(mirrorExecutor.execute).toHaveBeenCalledTimes(1);
+    const action = mirrorExecutor.execute.mock.calls[0][0];
+    expect(action.type).toBe('createFolder');
+    expect(action.payload.collectionKey).toBe('SUBA');
+    expect(action.payload.relativePath).toBe('MethodsA');
+    expect(action.payload.mappingId).toBe('mapa');
+  });
+
+  it('routes a folder-B collection to mapb (isolation — different owner)', async () => {
+    makeCollectionRegistry([ROOT_A, SUB_A, ROOT_B, SUB_B, ORPHAN]);
+    multiPrefs();
+    const getObs = captureObserverID();
+    start(makeCoordinator(makeStore()));
+
+    await getObs().notify('add', 'collection', [SUB_B.id], {});
+
+    expect(mirrorExecutor.execute).toHaveBeenCalledTimes(1);
+    expect(mirrorExecutor.execute.mock.calls[0][0].payload.mappingId).toBe('mapb');
+  });
+
+  it('drops events on a collection no watch folder owns', async () => {
+    makeCollectionRegistry([ROOT_A, SUB_A, ROOT_B, SUB_B, ORPHAN]);
+    multiPrefs();
+    const getObs = captureObserverID();
+    start(makeCoordinator(makeStore()));
+
+    await getObs().notify('add', 'collection', [ORPHAN.id], {});
+
+    expect(mirrorExecutor.execute).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/fileScanner.test.mjs
+++ b/test/unit/fileScanner.test.mjs
@@ -21,6 +21,7 @@ import {
   hasFileChanged,
   scanFolder,
   scanFolderRecursive,
+  scanTree,
   __test_setSymlinkDetector,
 } from '../../content/fileScanner.mjs';
 import { isSupportedFileType, filterSupportedFiles } from '../../content/fileImporter.mjs';
@@ -269,5 +270,193 @@ describe('UT-A2: scanner result shape (relativePath + isSymlink)', () => {
     // No entry for the symlink — its isSymlink is implicitly true but never observed.
     expect(files.find(f => f.path === '/watch/link.pdf')).toBeUndefined();
     __test_setSymlinkDetector(null);
+  });
+});
+
+// ─── UT-A3 — scanTree incremental cached walk (Option 1 scan optimization) ───
+//
+// scanTree returns the SAME complete file view as scanFolderRecursive PLUS the
+// subdir set, but skips getChildren()+per-file stat() for directories whose
+// mtime is unchanged. These tests pin: completeness, that unchanged dirs are
+// NOT re-enumerated, that structural changes (add/remove/nested) ARE picked up,
+// and that clearing the cache forces a full sweep.
+
+describe('UT-A3: scanTree incremental cached walk', () => {
+  /**
+   * Install an in-memory filesystem wired to IOUtils.
+   * @param {Map<string,{type:'dir'|'file', mtime:number, size?:number, children?:string[]}>} nodes
+   * @returns {import('vitest').Mock} the getChildren spy (to count enumerations)
+   */
+  function installFs(nodes) {
+    globalThis.IOUtils.exists = vi.fn(async (p) => nodes.has(p));
+    globalThis.IOUtils.stat = vi.fn(async (p) => {
+      const n = nodes.get(p);
+      if (!n) throw Object.assign(new Error('NotFound'), { name: 'NotFoundError' });
+      return n.type === 'dir'
+        ? { type: 'directory', size: 0, lastModified: n.mtime }
+        : { type: 'regular', size: n.size ?? 100, lastModified: n.mtime };
+    });
+    const gc = vi.fn(async (p) => {
+      const n = nodes.get(p);
+      return (n && n.children) ? [...n.children] : [];
+    });
+    globalThis.IOUtils.getChildren = gc;
+    return gc;
+  }
+
+  /** A small nested tree: /watch → a.pdf, sub/ → sub/b.pdf */
+  function baseTree() {
+    return new Map([
+      ['/watch', { type: 'dir', mtime: 1, children: ['/watch/a.pdf', '/watch/sub'] }],
+      ['/watch/a.pdf', { type: 'file', mtime: 1 }],
+      ['/watch/sub', { type: 'dir', mtime: 1, children: ['/watch/sub/b.pdf'] }],
+      ['/watch/sub/b.pdf', { type: 'file', mtime: 1 }],
+    ]);
+  }
+
+  beforeEach(() => {
+    __test_setSymlinkDetector(null);
+    globalThis.Zotero.Prefs.get = vi.fn(() => undefined); // isAllowedFileType → 'pdf'
+    globalThis.Zotero.debug = vi.fn();
+  });
+
+  it('returns the complete file list + subdir set (null cache = full walk)', async () => {
+    installFs(baseTree());
+    const { files, dirs } = await scanTree('/watch', null);
+
+    expect(files.map(f => f.path).sort()).toEqual(['/watch/a.pdf', '/watch/sub/b.pdf']);
+    expect(dirs).toEqual(['/watch/sub']);
+    // relativePath is anchored at the root.
+    expect(files.find(f => f.path === '/watch/sub/b.pdf').relativePath).toBe('sub/b.pdf');
+  });
+
+  it('skips getChildren() for unchanged dirs on the second walk, but returns the same files', async () => {
+    const nodes = baseTree();
+    const gc = installFs(nodes);
+    const cache = new Map();
+
+    const first = await scanTree('/watch', cache);
+    expect(first.files).toHaveLength(2);
+    expect(gc).toHaveBeenCalled(); // full enumeration first time
+
+    gc.mockClear();
+    const second = await scanTree('/watch', cache);
+    // Nothing changed → NO directory re-enumerated…
+    expect(gc).not.toHaveBeenCalled();
+    // …yet the complete file view is still returned from cache.
+    expect(second.files.map(f => f.path).sort()).toEqual(['/watch/a.pdf', '/watch/sub/b.pdf']);
+    expect(second.dirs).toEqual(['/watch/sub']);
+  });
+
+  it('re-enumerates a dir whose mtime bumped and picks up the new file', async () => {
+    const nodes = baseTree();
+    const gc = installFs(nodes);
+    const cache = new Map();
+    await scanTree('/watch', cache);
+
+    // Add a file at the root and bump /watch mtime (a real FS bumps dir mtime
+    // on child add).
+    nodes.set('/watch/c.pdf', { type: 'file', mtime: 2 });
+    nodes.get('/watch').children.push('/watch/c.pdf');
+    nodes.get('/watch').mtime = 2;
+
+    gc.mockClear();
+    const r = await scanTree('/watch', cache);
+    expect(gc).toHaveBeenCalledWith('/watch');      // changed dir re-enumerated
+    expect(gc).not.toHaveBeenCalledWith('/watch/sub'); // unchanged dir reused
+    expect(r.files.map(f => f.path)).toContain('/watch/c.pdf');
+  });
+
+  it('drops a deleted file when its parent dir mtime bumps (deletion detection stays correct)', async () => {
+    const nodes = baseTree();
+    installFs(nodes);
+    const cache = new Map();
+    await scanTree('/watch', cache);
+
+    // Delete /watch/a.pdf and bump the parent mtime.
+    nodes.delete('/watch/a.pdf');
+    nodes.get('/watch').children = ['/watch/sub'];
+    nodes.get('/watch').mtime = 2;
+
+    const r = await scanTree('/watch', cache);
+    expect(r.files.map(f => f.path)).toEqual(['/watch/sub/b.pdf']);
+  });
+
+  it('detects a change nested under an UNCHANGED parent (recursion always descends)', async () => {
+    const nodes = baseTree();
+    const gc = installFs(nodes);
+    const cache = new Map();
+    await scanTree('/watch', cache);
+
+    // Parent /watch unchanged; only the child /watch/sub changes.
+    nodes.set('/watch/sub/d.pdf', { type: 'file', mtime: 2 });
+    nodes.get('/watch/sub').children.push('/watch/sub/d.pdf');
+    nodes.get('/watch/sub').mtime = 2;
+
+    gc.mockClear();
+    const r = await scanTree('/watch', cache);
+    expect(gc).not.toHaveBeenCalledWith('/watch');     // parent was a cache hit
+    expect(gc).toHaveBeenCalledWith('/watch/sub');      // nested change re-enumerated
+    expect(r.files.map(f => f.path)).toContain('/watch/sub/d.pdf');
+  });
+
+  it('clearing the cache forces a full sweep (every dir re-enumerated)', async () => {
+    const nodes = baseTree();
+    const gc = installFs(nodes);
+    const cache = new Map();
+    await scanTree('/watch', cache);
+
+    gc.mockClear();
+    cache.clear(); // simulate the periodic full sweep
+    await scanTree('/watch', cache);
+    expect(gc).toHaveBeenCalledWith('/watch');
+    expect(gc).toHaveBeenCalledWith('/watch/sub');
+  });
+
+  it('null cache never short-circuits (full walk every call)', async () => {
+    const nodes = baseTree();
+    const gc = installFs(nodes);
+    await scanTree('/watch', null);
+    gc.mockClear();
+    await scanTree('/watch', null);
+    expect(gc).toHaveBeenCalledWith('/watch');
+    expect(gc).toHaveBeenCalledWith('/watch/sub');
+  });
+
+  it('skips symlinked dirs and reserved dirs (parity with scanFolderRecursive)', async () => {
+    const nodes = new Map([
+      ['/watch', { type: 'dir', mtime: 1, children: ['/watch/keep.pdf', '/watch/link', '/watch/imported'] }],
+      ['/watch/keep.pdf', { type: 'file', mtime: 1 }],
+      ['/watch/link', { type: 'dir', mtime: 1, children: ['/watch/link/escaped.pdf'] }],
+      ['/watch/link/escaped.pdf', { type: 'file', mtime: 1 }],
+      ['/watch/imported', { type: 'dir', mtime: 1, children: ['/watch/imported/old.pdf'] }],
+      ['/watch/imported/old.pdf', { type: 'file', mtime: 1 }],
+    ]);
+    installFs(nodes);
+    __test_setSymlinkDetector((p) => p === '/watch/link');
+
+    const { files, dirs } = await scanTree('/watch', new Map());
+    const paths = files.map(f => f.path);
+    expect(paths).toEqual(['/watch/keep.pdf']);
+    expect(paths).not.toContain('/watch/link/escaped.pdf');   // symlinked dir skipped
+    expect(paths).not.toContain('/watch/imported/old.pdf');   // reserved dir skipped
+    expect(dirs).toEqual([]);
+    __test_setSymlinkDetector(null);
+  });
+
+  it('returns empty and forgets the cache entry when the root is gone (fail-safe)', async () => {
+    const nodes = baseTree();
+    installFs(nodes);
+    const cache = new Map();
+    await scanTree('/watch', cache);
+    expect(cache.has('/watch')).toBe(true);
+
+    // Root vanishes (e.g. transient unmount).
+    const empty = new Map();
+    installFs(empty);
+    const r = await scanTree('/watch', cache);
+    expect(r.files).toEqual([]);
+    expect(r.dirs).toEqual([]);
+    expect(cache.has('/watch')).toBe(false); // stale snapshot dropped
   });
 });

--- a/test/unit/itemMembershipHandler.test.mjs
+++ b/test/unit/itemMembershipHandler.test.mjs
@@ -40,6 +40,9 @@ vi.mock('../../content/utils.mjs', async () => {
 vi.mock('../../content/baseline.mjs', () => ({
   copyAttachmentToCanonical: vi.fn(async () => 'copied'),
   adoptCollectionSubtree: vi.fn(async () => ({ ok: true })),
+  // Baseline-completion is now queried via isBaselineNeeded(ctx) (per-mapping
+  // aware). Default: baseline NOT complete → untracked adds defer.
+  isBaselineNeeded: vi.fn(async () => true),
   // Mirrors the real helper: collection scope → collection key; library → key.
   baselineKeyFor: vi.fn((syncRoot) =>
     syncRoot?.isLibraryRoot ? `__library__:${syncRoot.libraryID}` : (syncRoot?.collection?.key ?? '')),
@@ -100,6 +103,9 @@ beforeEach(() => {
   // names: '', 'Methods', 'OldFolder', 'NewFolder').
   collectionKeyToDiskRelativePath.mockImplementation((k) => collectionKeyToRelativePath(k));
   chooseCanonicalCollection.mockResolvedValue(null);
+  // Default: baseline not complete → untracked adds defer (reset per test since
+  // clearAllMocks keeps implementations).
+  baseline.isBaselineNeeded.mockResolvedValue(true);
 });
 
 // ─── UT-501 ────────────────────────────────────────────────────────────────
@@ -149,7 +155,8 @@ describe('UT-502: add on untracked item → defer (B.2 case)', () => {
 
 describe('UT-513: add on untracked attachment AFTER baseline → adopt', () => {
   it('copies the attachment to its canonical path + creates a record when baseline is complete', async () => {
-    getPref.mockImplementation((k) => ({ baselineCompletedForRoot: 'ROOT1', sourcePath: '/watch' }[k]));
+    getPref.mockImplementation((k) => ({ sourcePath: '/watch' }[k]));
+    baseline.isBaselineNeeded.mockResolvedValue(false); // baseline complete → adopt
     const collection = { id: 200, key: 'SUB1' };
     const att = { key: 'NEWATT', isAttachment: () => true };
     Zotero.Collections.get.mockReturnValue(collection);
@@ -166,8 +173,9 @@ describe('UT-513: add on untracked attachment AFTER baseline → adopt', () => {
     expect(mirrorExecutor.execute).not.toHaveBeenCalled();
   });
 
-  it('still defers when baseline completed for a DIFFERENT root', async () => {
-    getPref.mockImplementation((k) => ({ baselineCompletedForRoot: 'OTHERROOT', sourcePath: '/watch' }[k]));
+  it('still defers when baseline is not complete', async () => {
+    getPref.mockImplementation((k) => ({ sourcePath: '/watch' }[k]));
+    baseline.isBaselineNeeded.mockResolvedValue(true); // not complete → defer
     const collection = { id: 200, key: 'SUB1' };
     const att = { key: 'NEWATT', isAttachment: () => true };
     Zotero.Collections.get.mockReturnValue(collection);
@@ -238,7 +246,14 @@ describe('UT-504: add triggers moveItem when canonical changes', () => {
     // mirrors safely). If this line is reverted to the raw
     // collectionKeyToRelativePath, the disk fn is never called here and this
     // assertion fails — keeping the live-path fix from silently rotting.
-    expect(collectionKeyToDiskRelativePath).toHaveBeenCalledWith('NEWC');
+    expect(collectionKeyToDiskRelativePath).toHaveBeenCalledWith('NEWC', null);
+    // Regression: the canonical CHOICE must also be scoped by the owning-mapping
+    // ctx (4th arg), not just the disk-path resolve. Pre-fix this was a 3-arg
+    // call, so chooseCanonicalCollection judged candidacy against the GLOBAL
+    // scope. Legacy single-root passes ctx=null (multi passes the mapping).
+    expect(chooseCanonicalCollection).toHaveBeenCalledWith(
+      expect.anything(), expect.anything(), expect.anything(), null,
+    );
   });
 
   it('does NOT emit moveItem when newCanonical equals current', async () => {

--- a/test/unit/mappingRouter.test.mjs
+++ b/test/unit/mappingRouter.test.mjs
@@ -1,0 +1,195 @@
+/**
+ * Unit tests for content/mappingRouter.mjs — the owning-mapping resolver.
+ *
+ * Covers the "nearest sync-root ancestor wins" rule (docs/mode2-mode3-design.md §5):
+ *   UT-MR1 no mappings / uncovered collection → null
+ *   UT-MR2 collection-scope: the sync root itself + nested descendants
+ *   UT-MR3 nearest-ancestor: deepest sync-root wins over a shallower one
+ *   UT-MR4 library-scope fallback owns everything not under a collection root
+ *   UT-MR5 collection-scope beats library-scope for its own subtree
+ *   UT-MR6 different library → not owned
+ *   UT-MR7 virtual/special view → never owned
+ *   UT-MR8 broken parent chain / cycle terminates safely
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../content/mappings.mjs', () => ({
+  getActiveMappings: vi.fn(() => []),
+}));
+vi.mock('../../content/canonicalPath.mjs', () => ({
+  // Real-equivalent: virtual tree rows carry a non-'C' treeViewID marker.
+  isSpecialCollection: (c) =>
+    typeof c?.treeViewID === 'string' && c.treeViewID.length > 0 && 'DUTPSFL'.includes(c.treeViewID[0]),
+}));
+
+import { mappingForCollection, mappingForItem } from '../../content/mappingRouter.mjs';
+import { getActiveMappings } from '../../content/mappings.mjs';
+
+// ── A small collection graph, wired to Zotero.Collections.get(id) ──────────
+//   PAPERS (10) ─ DRAFT (11) ─ SUB (12)      [library 1]
+//   OTHER  (20)                              [library 1, unrelated top-level]
+//   L2COLL (30)                              [library 2]
+const COLS = {
+  PAPERS: { id: 10, key: 'PAPERS00', libraryID: 1, parentID: null, treeViewID: 'C10' },
+  DRAFT: { id: 11, key: 'DRAFT000', libraryID: 1, parentID: 10, treeViewID: 'C11' },
+  SUB: { id: 12, key: 'SUB00000', libraryID: 1, parentID: 11, treeViewID: 'C12' },
+  OTHER: { id: 20, key: 'OTHER000', libraryID: 1, parentID: null, treeViewID: 'C20' },
+  L2COLL: { id: 30, key: 'L2COLL00', libraryID: 2, parentID: null, treeViewID: 'C30' },
+};
+
+function collMapping(id, key, libraryID = 1) {
+  return { id, scopeMode: 'collection', syncRootCollectionKey: key, syncRootLibraryID: libraryID };
+}
+function libMapping(id, libraryID = 1) {
+  return { id, scopeMode: 'library', syncRootCollectionKey: '', syncRootLibraryID: libraryID };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  const byId = new Map(Object.values(COLS).map((c) => [c.id, c]));
+  globalThis.Zotero = globalThis.Zotero || {};
+  globalThis.Zotero.Collections = { get: vi.fn((id) => byId.get(id) || null) };
+  globalThis.Zotero.Libraries = { userLibraryID: 1 };
+});
+
+// ── UT-MR1 ──────────────────────────────────────────────────────────────
+describe('UT-MR1: no owner', () => {
+  it('returns null when there are no active mappings', () => {
+    getActiveMappings.mockReturnValue([]);
+    expect(mappingForCollection(COLS.PAPERS)).toBe(null);
+  });
+  it('returns null for a null collection', () => {
+    getActiveMappings.mockReturnValue([collMapping('A', 'PAPERS00')]);
+    expect(mappingForCollection(null)).toBe(null);
+  });
+  it('returns null for a collection outside every collection-scope subtree (no library mapping)', () => {
+    getActiveMappings.mockReturnValue([collMapping('A', 'PAPERS00')]);
+    expect(mappingForCollection(COLS.OTHER)).toBe(null);
+  });
+});
+
+// ── UT-MR2 ──────────────────────────────────────────────────────────────
+describe('UT-MR2: collection scope — root and descendants', () => {
+  it('the sync-root collection itself is owned', () => {
+    const A = collMapping('A', 'PAPERS00');
+    getActiveMappings.mockReturnValue([A]);
+    expect(mappingForCollection(COLS.PAPERS)).toBe(A);
+  });
+  it('a nested descendant is owned by the ancestor mapping', () => {
+    const A = collMapping('A', 'PAPERS00');
+    getActiveMappings.mockReturnValue([A]);
+    expect(mappingForCollection(COLS.SUB)).toBe(A); // SUB → DRAFT → PAPERS
+  });
+});
+
+// ── UT-MR3 ──────────────────────────────────────────────────────────────
+describe('UT-MR3: nearest ancestor wins', () => {
+  it('deepest sync-root owns a collection nested under both', () => {
+    const A = collMapping('A', 'PAPERS00'); // shallow
+    const B = collMapping('B', 'DRAFT000'); // deep (under PAPERS)
+    getActiveMappings.mockReturnValue([A, B]);
+    expect(mappingForCollection(COLS.SUB)).toBe(B);   // nearest is DRAFT
+    expect(mappingForCollection(COLS.DRAFT)).toBe(B);
+    expect(mappingForCollection(COLS.PAPERS)).toBe(A); // above DRAFT → PAPERS
+  });
+  it('order in the mappings array does not change the result', () => {
+    const A = collMapping('A', 'PAPERS00');
+    const B = collMapping('B', 'DRAFT000');
+    getActiveMappings.mockReturnValue([B, A]); // reversed
+    expect(mappingForCollection(COLS.SUB)).toBe(B);
+  });
+});
+
+// ── UT-MR4 ──────────────────────────────────────────────────────────────
+describe('UT-MR4: library-scope fallback', () => {
+  it('owns any collection in its library not under a collection root', () => {
+    const L = libMapping('L');
+    getActiveMappings.mockReturnValue([L]);
+    expect(mappingForCollection(COLS.OTHER)).toBe(L);
+    expect(mappingForCollection(COLS.SUB)).toBe(L);
+  });
+});
+
+// ── UT-MR5 ──────────────────────────────────────────────────────────────
+describe('UT-MR5: collection scope beats library fallback within its subtree', () => {
+  it('collection mapping owns its subtree; library mapping owns the rest', () => {
+    const A = collMapping('A', 'PAPERS00');
+    const L = libMapping('L');
+    getActiveMappings.mockReturnValue([A, L]);
+    expect(mappingForCollection(COLS.SUB)).toBe(A);    // under PAPERS
+    expect(mappingForCollection(COLS.OTHER)).toBe(L);  // elsewhere in the library
+  });
+});
+
+// ── UT-MR6 ──────────────────────────────────────────────────────────────
+describe('UT-MR6: library isolation', () => {
+  it('a mapping in library 1 does not own a library-2 collection', () => {
+    getActiveMappings.mockReturnValue([collMapping('A', 'PAPERS00', 1), libMapping('L', 1)]);
+    expect(mappingForCollection(COLS.L2COLL)).toBe(null);
+  });
+  it('a library-2 mapping owns the library-2 collection', () => {
+    const L2 = libMapping('L2', 2);
+    getActiveMappings.mockReturnValue([libMapping('L', 1), L2]);
+    expect(mappingForCollection(COLS.L2COLL)).toBe(L2);
+  });
+});
+
+// ── UT-MR7 ──────────────────────────────────────────────────────────────
+describe('UT-MR7: virtual views are never owned', () => {
+  it('returns null for a Trash/virtual collection even with a library mapping', () => {
+    getActiveMappings.mockReturnValue([libMapping('L')]);
+    const trash = { key: 'x', libraryID: 1, parentID: null, treeViewID: 'T1' };
+    expect(mappingForCollection(trash)).toBe(null);
+  });
+});
+
+// ── UT-MR8 ──────────────────────────────────────────────────────────────
+describe('UT-MR8: broken parent chain terminates safely', () => {
+  it('a self-referential parentID does not loop forever', () => {
+    const cyc = { id: 40, key: 'CYCLE000', libraryID: 1, parentID: 40, treeViewID: 'C40' };
+    globalThis.Zotero.Collections.get = vi.fn((id) => (id === 40 ? cyc : null));
+    getActiveMappings.mockReturnValue([collMapping('A', 'PAPERS00')]);
+    expect(mappingForCollection(cyc)).toBe(null); // not owned, and returns (no hang)
+  });
+});
+
+// ── UT-MR9: mappingForItem ────────────────────────────────────────────────
+describe('UT-MR9: mappingForItem', () => {
+  /** Build a Zotero-item-like object with collection memberships (by id). */
+  function item(collectionIDs, libraryID = 1) {
+    return { libraryID, getCollections: () => collectionIDs };
+  }
+
+  it('attributes an item to the mapping owning one of its collections', () => {
+    const A = collMapping('A', 'PAPERS00');
+    getActiveMappings.mockReturnValue([A]);
+    expect(mappingForItem(item([COLS.SUB.id]))).toBe(A); // SUB is under PAPERS
+  });
+
+  it('an Unfiled item (no collections) falls back to the library-scope mapping', () => {
+    const L = libMapping('L');
+    getActiveMappings.mockReturnValue([L]);
+    expect(mappingForItem(item([]))).toBe(L);
+  });
+
+  it('an Unfiled item with no library-scope mapping is unowned', () => {
+    getActiveMappings.mockReturnValue([collMapping('A', 'PAPERS00')]);
+    expect(mappingForItem(item([]))).toBe(null);
+  });
+
+  it('an item only in unwatched collections is unowned', () => {
+    getActiveMappings.mockReturnValue([collMapping('A', 'PAPERS00')]);
+    expect(mappingForItem(item([COLS.OTHER.id]))).toBe(null); // OTHER not under PAPERS, no lib mapping
+  });
+
+  it('a library-scope item in a different library is unowned', () => {
+    getActiveMappings.mockReturnValue([libMapping('L', 1)]);
+    expect(mappingForItem(item([], 2))).toBe(null);
+  });
+
+  it('returns null for a null item', () => {
+    getActiveMappings.mockReturnValue([libMapping('L')]);
+    expect(mappingForItem(null)).toBe(null);
+  });
+});

--- a/test/unit/mappings.test.mjs
+++ b/test/unit/mappings.test.mjs
@@ -1,0 +1,275 @@
+/**
+ * Unit tests for content/mappings.mjs — the multi-mapping registry.
+ *
+ * Covers:
+ *   UT-M1 isMultiMappingActive (gate)
+ *   UT-M2 synthesizeLegacyMapping (single-root fallback shape)
+ *   UT-M3 getActiveMappings (gate off → synth; gate on → parsed; malformed → fallback; dedup ids)
+ *   UT-M4 getMappingById (match / legacy fallback / unknown)
+ *   UT-M5 watchRootsOverlap (equal / nested / sibling)
+ *   UT-M6 validateMapping (empty / overlap / data-dir unsafe / ok)
+ *   UT-M7 readMappings / writeMappings round-trip
+ *   UT-M8 mintMappingId (returns a non-empty string)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  LEGACY_MAPPING_ID,
+  isMultiMappingActive,
+  effectiveGlobalMode,
+  synthesizeLegacyMapping,
+  getActiveMappings,
+  getMappingById,
+  watchRootsOverlap,
+  validateMapping,
+  readMappings,
+  writeMappings,
+  mintMappingId,
+  __test_setActiveMappings,
+} from '../../content/mappings.mjs';
+
+const PREFIX = 'extensions.zotero.watchFolder.';
+
+/** In-memory pref store wired to Zotero.Prefs.get/set (what utils.getPref/setPref call). */
+function installPrefs(values = {}) {
+  const store = { ...values };
+  Zotero.Prefs.get = vi.fn((fullKey) => {
+    if (fullKey.startsWith(PREFIX)) return store[fullKey.slice(PREFIX.length)];
+    return undefined;
+  });
+  Zotero.Prefs.set = vi.fn((fullKey, val) => {
+    if (fullKey.startsWith(PREFIX)) store[fullKey.slice(PREFIX.length)] = val;
+  });
+  return store;
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  Zotero.debug = vi.fn();
+  Zotero.logError = vi.fn();
+  __test_setActiveMappings(null); // clear the test seam between cases
+});
+
+// ─── UT-M1 ───────────────────────────────────────────────────────────────
+describe('UT-M1: isMultiMappingActive', () => {
+  it('is false when the gate pref is unset', () => {
+    installPrefs({});
+    expect(isMultiMappingActive()).toBe(false);
+  });
+  it('is false when the gate pref is false, true only when strictly true', () => {
+    installPrefs({ watchMappingsMulti: false });
+    expect(isMultiMappingActive()).toBe(false);
+    installPrefs({ watchMappingsMulti: true });
+    expect(isMultiMappingActive()).toBe(true);
+  });
+});
+
+// ─── UT-M2 ───────────────────────────────────────────────────────────────
+describe('UT-M2: synthesizeLegacyMapping', () => {
+  it('builds a legacy-id context from the scalar prefs', () => {
+    installPrefs({
+      sourcePath: '/watch', scopeMode: 'collection', syncRootCollectionKey: 'ROOT1',
+      syncRootLibraryID: 1, mode: 'mode3', pdfStorageStrategy: 'linked_watch_folder',
+    });
+    const m = synthesizeLegacyMapping();
+    expect(m).toEqual({
+      id: LEGACY_MAPPING_ID, sourcePath: '/watch', scopeMode: 'collection',
+      syncRootCollectionKey: 'ROOT1', syncRootLibraryID: 1, mode: 'mode3',
+      pdfStorageStrategy: 'linked_watch_folder',
+    });
+  });
+  it("scopeMode is 'library' only when the pref is exactly 'library'", () => {
+    installPrefs({ sourcePath: '/w', scopeMode: 'library' });
+    expect(synthesizeLegacyMapping().scopeMode).toBe('library');
+    installPrefs({ sourcePath: '/w' }); // unset → collection (matches getScopeMode)
+    expect(synthesizeLegacyMapping().scopeMode).toBe('collection');
+  });
+});
+
+// ─── UT-M3 ───────────────────────────────────────────────────────────────
+describe('UT-M3: getActiveMappings', () => {
+  it('returns a single synthesized legacy mapping when the gate is off', () => {
+    installPrefs({ sourcePath: '/watch', mode: 'mode1', watchMappings: '[]' });
+    const ms = getActiveMappings();
+    expect(ms).toHaveLength(1);
+    expect(ms[0].id).toBe(LEGACY_MAPPING_ID);
+    expect(ms[0].sourcePath).toBe('/watch');
+  });
+
+  it('parses N mappings when the gate is on', () => {
+    const mappings = [
+      { id: 'aaaa1111', sourcePath: '/A', scopeMode: 'collection', syncRootCollectionKey: 'CA', syncRootLibraryID: 1, mode: 'mode1', pdfStorageStrategy: 'stored' },
+      { id: 'bbbb2222', sourcePath: '/B', scopeMode: 'library', syncRootCollectionKey: '', syncRootLibraryID: 3, mode: 'mode3', pdfStorageStrategy: 'linked_watch_folder' },
+    ];
+    installPrefs({ watchMappingsMulti: true, watchMappings: JSON.stringify(mappings) });
+    const ms = getActiveMappings();
+    expect(ms.map(m => m.id)).toEqual(['aaaa1111', 'bbbb2222']);
+    expect(ms[0].sourcePath).toBe('/A');
+    expect(ms[1].scopeMode).toBe('library');
+    expect(ms[1].syncRootLibraryID).toBe(3);
+  });
+
+  it('falls back to the synthesized legacy mapping when the gate is on but the JSON is malformed', () => {
+    installPrefs({ watchMappingsMulti: true, watchMappings: 'not json', sourcePath: '/watch' });
+    const ms = getActiveMappings();
+    expect(ms).toHaveLength(1);
+    expect(ms[0].id).toBe(LEGACY_MAPPING_ID);
+  });
+
+  it('returns [] (watch nothing) for a valid EMPTY array — does NOT resurrect legacy scalars', () => {
+    // All folders removed: an empty list must mean "no folders", not a phantom
+    // watch of the stale single-root sourcePath/collection.
+    installPrefs({ watchMappingsMulti: true, watchMappings: '[]', sourcePath: '/watch', syncRootCollectionKey: 'DEADKEY0' });
+    expect(getActiveMappings()).toEqual([]);
+  });
+
+  it('drops entries with no sourcePath and duplicate ids', () => {
+    const mappings = [
+      { id: 'x', sourcePath: '/A' },
+      { id: 'y' },                    // no sourcePath → dropped
+      { id: 'x', sourcePath: '/C' },  // duplicate id → dropped
+      { id: 'z', sourcePath: '/D' },
+    ];
+    installPrefs({ watchMappingsMulti: true, watchMappings: JSON.stringify(mappings) });
+    expect(getActiveMappings().map(m => m.id)).toEqual(['x', 'z']);
+  });
+
+  it('honors the __test_setActiveMappings seam', () => {
+    installPrefs({});
+    __test_setActiveMappings([{ id: 'seam', sourcePath: '/S', scopeMode: 'collection', mode: 'mode1' }]);
+    const ms = getActiveMappings();
+    expect(ms).toHaveLength(1);
+    expect(ms[0].id).toBe('seam');
+  });
+});
+
+// ─── UT-M4 ───────────────────────────────────────────────────────────────
+describe('UT-M4: getMappingById', () => {
+  it('returns the matching active mapping', () => {
+    installPrefs({ watchMappingsMulti: true, watchMappings: JSON.stringify([{ id: 'q1', sourcePath: '/Q' }]) });
+    expect(getMappingById('q1').sourcePath).toBe('/Q');
+  });
+  it('falls back to the synthesized legacy mapping for the legacy id', () => {
+    installPrefs({ sourcePath: '/watch' });
+    expect(getMappingById(LEGACY_MAPPING_ID).sourcePath).toBe('/watch');
+  });
+  it('returns null for an unknown id', () => {
+    installPrefs({ watchMappingsMulti: true, watchMappings: JSON.stringify([{ id: 'q1', sourcePath: '/Q' }]) });
+    expect(getMappingById('nope')).toBe(null);
+  });
+});
+
+// ─── UT-M5 ───────────────────────────────────────────────────────────────
+describe('UT-M5: watchRootsOverlap', () => {
+  it('flags identical roots', () => {
+    expect(watchRootsOverlap('/a/b', '/a/b')).toBe(true);
+  });
+  it('flags a nested root (either direction)', () => {
+    expect(watchRootsOverlap('/a', '/a/b')).toBe(true);
+    expect(watchRootsOverlap('/a/b', '/a')).toBe(true);
+  });
+  it('allows siblings / unrelated roots', () => {
+    expect(watchRootsOverlap('/a/b', '/a/c')).toBe(false);
+    expect(watchRootsOverlap('/a-backup', '/a')).toBe(false); // not a real prefix
+  });
+});
+
+// ─── UT-M6 ───────────────────────────────────────────────────────────────
+describe('UT-M6: validateMapping', () => {
+  const dataDir = '/Users/me/Zotero';
+  it('rejects an empty path', () => {
+    expect(validateMapping({ sourcePath: '' }, [], dataDir)).toMatch(/watch folder is required/i);
+  });
+  it('rejects a path overlapping an existing mapping', () => {
+    const existing = [{ id: 'a', sourcePath: '/watch/A' }];
+    expect(validateMapping({ id: 'b', sourcePath: '/watch/A/sub' }, existing, dataDir)).toMatch(/overlaps/i);
+  });
+  it('rejects a path inside the Zotero data dir (isWatchRootUnsafe)', () => {
+    expect(validateMapping({ sourcePath: '/Users/me/Zotero/storage/x' }, [], dataDir)).toBeTruthy();
+  });
+  it('allows a disjoint, safe path', () => {
+    const existing = [{ id: 'a', sourcePath: '/watch/A' }];
+    expect(validateMapping({ id: 'b', sourcePath: '/watch/B' }, existing, dataDir)).toBe(null);
+  });
+  it('does not treat editing the same row as an overlap with itself', () => {
+    const existing = [{ id: 'a', sourcePath: '/watch/A' }];
+    expect(validateMapping({ id: 'a', sourcePath: '/watch/A' }, existing, dataDir)).toBe(null);
+  });
+
+  // Target (Zotero-side) collisions — Mode 2/3 routing.
+  it('rejects a second whole-library mapping on the same library', () => {
+    const existing = [{ id: 'a', sourcePath: '/watch/A', scopeMode: 'library', syncRootLibraryID: 1 }];
+    const reason = validateMapping(
+      { id: 'b', sourcePath: '/watch/B', scopeMode: 'library', syncRootLibraryID: 1 }, existing, dataDir);
+    expect(reason).toMatch(/whole library/i);
+  });
+  it('rejects two mappings targeting the EXACT same collection', () => {
+    const existing = [{ id: 'a', sourcePath: '/watch/A', scopeMode: 'collection', syncRootCollectionKey: 'COLL1234', syncRootLibraryID: 1 }];
+    const reason = validateMapping(
+      { id: 'b', sourcePath: '/watch/B', scopeMode: 'collection', syncRootCollectionKey: 'COLL1234', syncRootLibraryID: 1 }, existing, dataDir);
+    expect(reason).toMatch(/exact same collection|already syncs this collection/i);
+  });
+  it('ALLOWS nested collection targets (nearest-ancestor auto-pick)', () => {
+    const existing = [{ id: 'a', sourcePath: '/watch/A', scopeMode: 'collection', syncRootCollectionKey: 'PARENT00', syncRootLibraryID: 1 }];
+    expect(validateMapping(
+      { id: 'b', sourcePath: '/watch/B', scopeMode: 'collection', syncRootCollectionKey: 'CHILD000', syncRootLibraryID: 1 }, existing, dataDir)).toBe(null);
+  });
+  it('ALLOWS a collection-scope mapping alongside a whole-library mapping', () => {
+    const existing = [{ id: 'a', sourcePath: '/watch/A', scopeMode: 'library', syncRootLibraryID: 1 }];
+    expect(validateMapping(
+      { id: 'b', sourcePath: '/watch/B', scopeMode: 'collection', syncRootCollectionKey: 'COLL1234', syncRootLibraryID: 1 }, existing, dataDir)).toBe(null);
+  });
+  it('ALLOWS the same collection key in DIFFERENT libraries', () => {
+    const existing = [{ id: 'a', sourcePath: '/watch/A', scopeMode: 'collection', syncRootCollectionKey: 'COLL1234', syncRootLibraryID: 1 }];
+    expect(validateMapping(
+      { id: 'b', sourcePath: '/watch/B', scopeMode: 'collection', syncRootCollectionKey: 'COLL1234', syncRootLibraryID: 5 }, existing, dataDir)).toBe(null);
+  });
+});
+
+// ─── UT-M7 ───────────────────────────────────────────────────────────────
+describe('UT-M7: readMappings / writeMappings', () => {
+  it('round-trips the mappings array through the pref', () => {
+    installPrefs({});
+    const mappings = [{ id: 'a', sourcePath: '/A' }, { id: 'b', sourcePath: '/B' }];
+    writeMappings(mappings);
+    expect(readMappings()).toEqual(mappings);
+  });
+  it('returns [] on a malformed pref', () => {
+    installPrefs({ watchMappings: '{not an array}' });
+    expect(readMappings()).toEqual([]);
+  });
+});
+
+// ─── UT-M8 ───────────────────────────────────────────────────────────────
+describe('UT-M8: mintMappingId', () => {
+  it('returns a non-empty string', () => {
+    installPrefs({});
+    const id = mintMappingId();
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+  });
+});
+
+// ─── UT-M9 ───────────────────────────────────────────────────────────────
+describe('UT-M9: effectiveGlobalMode (folder-list clamp)', () => {
+  it('single-root (multi off) returns the configured mode verbatim', () => {
+    installPrefs({ mode: 'mode3' });
+    expect(effectiveGlobalMode()).toBe('mode3');
+    installPrefs({ mode: 'mode2' });
+    expect(effectiveGlobalMode()).toBe('mode2');
+  });
+  it('defaults to mode1 when unset', () => {
+    installPrefs({});
+    expect(effectiveGlobalMode()).toBe('mode1');
+  });
+  it('multi active keeps mode1 and mode2 as-is', () => {
+    installPrefs({ watchMappingsMulti: true, mode: 'mode1' });
+    expect(effectiveGlobalMode()).toBe('mode1');
+    installPrefs({ watchMappingsMulti: true, mode: 'mode2' });
+    expect(effectiveGlobalMode()).toBe('mode2');
+  });
+  it('multi active CLAMPS mode3 → mode2 (deletes deferred to Stage B)', () => {
+    installPrefs({ watchMappingsMulti: true, mode: 'mode3' });
+    expect(effectiveGlobalMode()).toBe('mode2');
+  });
+});

--- a/test/unit/mirrorExecutor.test.mjs
+++ b/test/unit/mirrorExecutor.test.mjs
@@ -1093,6 +1093,32 @@ describe('UT-419: _deleteFolder Mode 3 routes through plugin trash', () => {
     expect(IOUtils.move).not.toHaveBeenCalled();
     expect(store.getCollectionRecord('SUB1').state).toBe(STATE.OUT_OF_SCOPE_SUPPRESSED);
   });
+
+  it('multi active CLAMPS a mode3 pref to warn-only (no delete in the folder-list model)', async () => {
+    // Safety-critical: the executor reads the CLAMPED effectiveGlobalMode, not
+    // the raw pref. With multi active a stale/explicit mode3 must NOT delete —
+    // it degrades to Mode-2 warn-only until Stage B lands the delete guards.
+    getPref.mockImplementation((key) => {
+      if (key === 'sourcePath') return '/watch';
+      if (key === 'mode') return 'mode3';
+      if (key === 'watchMappingsMulti') return true;
+      return undefined;
+    });
+    const store = await makeStore();
+    store.add(createCollectionRecord({
+      localPath: 'Methods', zoteroCollectionKey: 'SUB1', state: STATE.CLEAN,
+    }));
+    init({ trackingStore: store });
+
+    const result = await execute({
+      type: 'deleteFolder',
+      payload: { collectionKey: 'SUB1', oldRelativePath: 'Methods' },
+    });
+
+    expect(result.reason).toBe('warn-only-mode2'); // clamped, not deleted
+    expect(IOUtils.move).not.toHaveBeenCalled();
+    expect(store.getCollectionRecord('SUB1').state).toBe(STATE.OUT_OF_SCOPE_SUPPRESSED);
+  });
 });
 
 // ─── UT-420 (Track C — bulk-delete protection) ──────────────────────────────

--- a/test/unit/preferences.test.mjs
+++ b/test/unit/preferences.test.mjs
@@ -263,3 +263,40 @@ describe('Storage report + Empty Zotero trash + Missing files', () => {
     expect(Services.prompt.alert).toHaveBeenCalled();
   });
 });
+
+// ─── Paused status when a target collection is trashed/missing (v2.9.2) ──────
+describe('status header: paused when a mapping target is blocked', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  function configuredSingleRoot() {
+    return { enabled: true, setupCompleted: true, sourcePath: '/w', scopeMode: 'collection', syncRootCollectionKey: 'K1', mode: 'mode1' };
+  }
+
+  it('shows "Paused" when getMappingHealth reports a trashed target', () => {
+    Zotero.WatchFolder = {
+      getMappingHealth: () => [{ id: 'A', sourcePath: '/w', targetLabel: 'test1', ok: false, reason: 'trashed' }],
+    };
+    const { prefs, document } = loadPrefs(configuredSingleRoot());
+    prefs.onLoad();
+    const pill = document.get('watch-folder-status-pill');
+    expect(pill.textContent).toBe('Paused');
+    expect(pill.className).toContain('is-paused');
+    expect(document.get('watch-folder-status-summary').textContent.toLowerCase()).toContain('paused');
+  });
+
+  it('shows "Watching" when all mapping targets are healthy', () => {
+    Zotero.WatchFolder = {
+      getMappingHealth: () => [{ id: 'A', sourcePath: '/w', targetLabel: 'test1', ok: true, reason: null }],
+    };
+    const { prefs, document } = loadPrefs(configuredSingleRoot());
+    prefs.onLoad();
+    expect(document.get('watch-folder-status-pill').textContent).toBe('Watching');
+  });
+
+  it('does not throw when the bundle API is absent (best-effort)', () => {
+    Zotero.WatchFolder = undefined;
+    const { prefs, document } = loadPrefs(configuredSingleRoot());
+    expect(() => prefs.onLoad()).not.toThrow();
+    expect(document.get('watch-folder-status-pill').textContent).toBe('Watching');
+  });
+});

--- a/test/unit/reconcile.test.mjs
+++ b/test/unit/reconcile.test.mjs
@@ -10,7 +10,7 @@
  *   UT-RC-6 applyRepairs: rehome / drop / cleanup / skip
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('../../content/utils.mjs', async () => {
   const actual = await vi.importActual('../../content/utils.mjs');
@@ -44,6 +44,8 @@ import * as reconcile from '../../content/reconcile.mjs';
 import { resolveSyncRoot, relativePathToCollection } from '../../content/canonicalPath.mjs';
 import { getTrackingStore } from '../../content/trackingStore.mjs';
 import { isWatchRootAvailable, classifyMissingFile } from '../../content/fileMissing.mjs';
+import { getPref } from '../../content/utils.mjs';
+import { __test_setActiveMappings } from '../../content/mappings.mjs';
 
 // Drive classifyMissingFile: paths in `gonePaths` (absolute) → USER_DELETED.
 function setGone(gonePaths) {
@@ -90,6 +92,14 @@ beforeEach(() => {
   resolveSyncRoot.mockResolvedValue({ collection: null, libraryID: 1, isLibraryRoot: true });
   isWatchRootAvailable.mockResolvedValue(true);
   classifyMissingFile.mockImplementation(async () => MC.STILL_EXISTS); // present unless a test marks gone
+});
+
+afterEach(() => {
+  // Multi tests toggle the gate + inject mappings; restore single-root defaults
+  // so the rest of the suite (all multi-off) is unaffected. clearAllMocks does
+  // NOT reset implementations, so restore getPref explicitly.
+  __test_setActiveMappings(null);
+  getPref.mockImplementation(() => '/watch');
 });
 
 // ─── UT-RC-1 ─────────────────────────────────────────────────────────────────
@@ -348,5 +358,97 @@ describe('UT-RC-7: detect guards', () => {
     globalThis.Zotero.Items.getByLibraryAndKeyAsync = vi.fn(async () => ({ key: 'K1', deleted: false, getAnnotations: () => [], getNotes: () => [] }));
     const r = await reconcile.detect();
     expect(r.findings.find((x) => x.type === reconcile.FINDING.SHADOW_ORPHANED)).toBeUndefined();
+  });
+});
+
+// ─── UT-RC-8: trashed target (visibility) + stale-tracking (recovery) ───────
+describe('UT-RC-8: trashed sync-root + stale-tracking findings', () => {
+  it('single-root: a trashed/missing target yields SYNC_ROOT_TRASHED (not a silent bail)', async () => {
+    getTrackingStore.mockReturnValue(makeStore());
+    resolveSyncRoot.mockRejectedValue(new Error("Sync-root collection XYZ is in Zotero's trash"));
+    const r = await reconcile.detect();
+    expect(r.ok).toBe(true);
+    expect(r.findings).toHaveLength(1);
+    expect(r.findings[0].type).toBe(reconcile.FINDING.SYNC_ROOT_TRASHED);
+    expect(r.findings[0].defaultActionId).toBe('skip');
+  });
+
+  it('single-root: an UNCONFIGURED target (null, no throw) still returns no-sync-root', async () => {
+    getTrackingStore.mockReturnValue(makeStore());
+    resolveSyncRoot.mockResolvedValue(null);
+    const r = await reconcile.detect();
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('no-sync-root');
+  });
+
+  it('multi: a mapping whose target is trashed yields SYNC_ROOT_TRASHED (report-only)', async () => {
+    getPref.mockImplementation((k) => (k === 'watchMappingsMulti' ? true : '/watch'));
+    __test_setActiveMappings([{ id: 'A', sourcePath: '/watch/A', scopeMode: 'collection', syncRootCollectionKey: 'TRASH', syncRootLibraryID: 1, mode: 'mode1', pdfStorageStrategy: 'stored' }]);
+    getTrackingStore.mockReturnValue(makeStore());
+    resolveSyncRoot.mockRejectedValue(new Error('in trash'));
+    const r = await reconcile.detect();
+    expect(r.ok).toBe(true);
+    const f = r.findings.find((x) => x.type === reconcile.FINDING.SYNC_ROOT_TRASHED);
+    expect(f).toBeDefined();
+    expect(f._payload.mappingId).toBe('A');
+    expect(f.defaultActionId).toBe('skip');
+  });
+
+  it('multi: a record whose Zotero item is CONFIRMED trashed → STALE_TRACKING drop', async () => {
+    getPref.mockImplementation((k) => (k === 'watchMappingsMulti' ? true : '/watch'));
+    __test_setActiveMappings([{ id: 'A', sourcePath: '/watch/A', scopeMode: 'library', syncRootCollectionKey: '', syncRootLibraryID: 1, mode: 'mode1', pdfStorageStrategy: 'stored' }]);
+    const store = makeStore([{ ...fileRec({ localPath: 'x.pdf', key: 'ATT1' }), mappingId: 'A' }]);
+    getTrackingStore.mockReturnValue(store);
+    globalThis.Zotero.Items.getByLibraryAndKeyAsync = vi.fn(async () => ({ key: 'ATT1', deleted: true, getAnnotations: () => [], getNotes: () => [] }));
+    const r = await reconcile.detect();
+    const f = r.findings.find((x) => x.type === reconcile.FINDING.STALE_TRACKING);
+    expect(f).toBeDefined();
+    expect(f.defaultActionId).toBe('drop');
+    expect(f._payload.localPath).toBe('x.pdf');
+    expect(f._payload.mappingId).toBe('A');
+  });
+
+  it('multi: a record whose item is ALIVE is NOT flagged as stale', async () => {
+    getPref.mockImplementation((k) => (k === 'watchMappingsMulti' ? true : '/watch'));
+    __test_setActiveMappings([{ id: 'A', sourcePath: '/watch/A', scopeMode: 'library', syncRootCollectionKey: '', syncRootLibraryID: 1, mode: 'mode1', pdfStorageStrategy: 'stored' }]);
+    const store = makeStore([{ ...fileRec({ localPath: 'x.pdf', key: 'ATT1' }), mappingId: 'A' }]);
+    getTrackingStore.mockReturnValue(store);
+    globalThis.Zotero.Items.getByLibraryAndKeyAsync = vi.fn(async () => ({ key: 'ATT1', deleted: false, getAnnotations: () => [], getNotes: () => [] }));
+    const r = await reconcile.detect();
+    expect(r.findings.find((x) => x.type === reconcile.FINDING.STALE_TRACKING)).toBeUndefined();
+  });
+
+  it('multi: a USER_DETACHED record is NOT flagged even if its item is trashed (respects intent)', async () => {
+    getPref.mockImplementation((k) => (k === 'watchMappingsMulti' ? true : '/watch'));
+    __test_setActiveMappings([{ id: 'A', sourcePath: '/watch/A', scopeMode: 'library', syncRootCollectionKey: '', syncRootLibraryID: 1, mode: 'mode1', pdfStorageStrategy: 'stored' }]);
+    const store = makeStore([{ ...fileRec({ localPath: 'x.pdf', key: 'ATT1', state: 'user-detached' }), mappingId: 'A' }]);
+    getTrackingStore.mockReturnValue(store);
+    globalThis.Zotero.Items.getByLibraryAndKeyAsync = vi.fn(async () => ({ key: 'ATT1', deleted: true, getAnnotations: () => [], getNotes: () => [] }));
+    const r = await reconcile.detect();
+    expect(r.findings.find((x) => x.type === reconcile.FINDING.STALE_TRACKING)).toBeUndefined();
+  });
+
+  it('multi: STALE_TRACKING drop removes the record (item STILL trashed at apply)', async () => {
+    getPref.mockImplementation((k) => (k === 'watchMappingsMulti' ? true : '/watch'));
+    __test_setActiveMappings([{ id: 'A', sourcePath: '/watch/A', scopeMode: 'library', syncRootCollectionKey: '', syncRootLibraryID: 1, mode: 'mode1', pdfStorageStrategy: 'stored' }]);
+    const store = makeStore([{ ...fileRec({ localPath: 'x.pdf', key: 'ATT1' }), mappingId: 'A' }]);
+    getTrackingStore.mockReturnValue(store);
+    globalThis.Zotero.Items.getByLibraryAndKeyAsync = vi.fn(async () => ({ key: 'ATT1', deleted: true }));
+    const findings = [{ id: 'f0', type: reconcile.FINDING.STALE_TRACKING, defaultActionId: 'drop', _payload: { localPath: 'x.pdf', attKey: 'ATT1', mappingId: 'A', libraryID: 1 } }];
+    const res = await reconcile.applyRepairs(findings, { f0: 'drop' });
+    expect(res.applied).toBe(1);
+    expect(store.remove).toHaveBeenCalledWith('x.pdf', 'A');
+  });
+
+  it('multi: STALE_TRACKING drop ABORTS if the item came back to life (TOCTOU)', async () => {
+    getPref.mockImplementation((k) => (k === 'watchMappingsMulti' ? true : '/watch'));
+    __test_setActiveMappings([{ id: 'A', sourcePath: '/watch/A', scopeMode: 'library', syncRootCollectionKey: '', syncRootLibraryID: 1, mode: 'mode1', pdfStorageStrategy: 'stored' }]);
+    const store = makeStore([{ ...fileRec({ localPath: 'x.pdf', key: 'ATT1' }), mappingId: 'A' }]);
+    getTrackingStore.mockReturnValue(store);
+    globalThis.Zotero.Items.getByLibraryAndKeyAsync = vi.fn(async () => ({ key: 'ATT1', deleted: false })); // alive again
+    const findings = [{ id: 'f0', type: reconcile.FINDING.STALE_TRACKING, defaultActionId: 'drop', _payload: { localPath: 'x.pdf', attKey: 'ATT1', mappingId: 'A', libraryID: 1 } }];
+    const res = await reconcile.applyRepairs(findings, { f0: 'drop' });
+    expect(res.failed).toBe(1);
+    expect(store.remove).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/watchFolder.test.mjs
+++ b/test/unit/watchFolder.test.mjs
@@ -17,7 +17,7 @@
  *   UT-095: RST.5 re-attach under living parent
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('../../content/utils.mjs', () => ({
   getPref: vi.fn(),
@@ -80,6 +80,7 @@ vi.mock('../../content/fileMissing.mjs', () => {
 vi.mock('../../content/fileScanner.mjs', () => ({
   scanFolder: vi.fn(),
   scanFolderRecursive: vi.fn(),
+  scanTree: vi.fn(async () => ({ files: [], dirs: [] })),
   SKIP_DIRNAMES: Object.freeze(new Set(['imported', '.zotero-watch-trash'])),
 }));
 
@@ -197,7 +198,7 @@ describe('WatchFolderService — Mode 1 deletion gates', () => {
 
     await service._handleExternalDeletions(new Set(), []);
 
-    expect(service._trackingStore.update).toHaveBeenCalledWith('/watch/gone.pdf', { state: 'missing' });
+    expect(service._trackingStore.update).toHaveBeenCalledWith('/watch/gone.pdf', { state: 'missing' }, 'legacy');
     // Mode 1 must NOT trash the Zotero attachment.
     expect(globalThis.Zotero.Items.getByLibraryAndKeyAsync).not.toHaveBeenCalled();
     expect(service._trackingStore.removeByAttachmentKey).not.toHaveBeenCalled();
@@ -527,7 +528,7 @@ describe('UT-053: WatchFolderService move detection (drag-into-subfolder) — v2
 
     expect(movedItem.deleted).toBe(false);
     expect(globalThis.Services.prompt.alert).not.toHaveBeenCalled();
-    expect(service._trackingStore.remove).toHaveBeenCalledWith('/watch/paper.pdf');
+    expect(service._trackingStore.remove).toHaveBeenCalledWith('/watch/paper.pdf', 'legacy');
     expect(service._trackingStore.add).toHaveBeenCalledWith(
       // Post-#25 migration: localPath is now sync-root-relative.
       expect.objectContaining({ localPath: 'sub/paper.pdf', zoteroAttachmentKey: 'AK42' })
@@ -546,7 +547,7 @@ describe('UT-053: WatchFolderService move detection (drag-into-subfolder) — v2
     );
 
     // Should have asked canonicalPath to resolve "sub" under the sync root.
-    expect(relativePathToCollectionMock).toHaveBeenCalledWith('sub', { createIfMissing: true });
+    expect(relativePathToCollectionMock).toHaveBeenCalledWith('sub', { createIfMissing: true }, expect.anything());
     expect(movedItem.removeFromCollection).toHaveBeenCalledWith(5);
     expect(movedItem.addToCollection).toHaveBeenCalled();
     expect(movedItem.saveTx).toHaveBeenCalled();
@@ -586,7 +587,7 @@ describe('UT-053: WatchFolderService move detection (drag-into-subfolder) — v2
     expect(movedItem.deleted).toBe(false);
     expect(globalThis.Zotero.Items.getByLibraryAndKeyAsync).not.toHaveBeenCalled();
     expect(globalThis.Services.prompt.alert).not.toHaveBeenCalled();
-    expect(service._trackingStore.update).toHaveBeenCalledWith('/watch/paper.pdf', { state: 'missing' });
+    expect(service._trackingStore.update).toHaveBeenCalledWith('/watch/paper.pdf', { state: 'missing' }, 'legacy');
     expect(service._trackingStore.add).not.toHaveBeenCalled();
   });
 
@@ -629,7 +630,7 @@ describe('UT-053: WatchFolderService move detection (drag-into-subfolder) — v2
     // Can't detect a move without a hash → fall through to the deletion
     // branch, which in Mode 1 just flips state=missing.
     expect(movedItem.deleted).toBe(false);
-    expect(service._trackingStore.update).toHaveBeenCalledWith('/watch/paper.pdf', { state: 'missing' });
+    expect(service._trackingStore.update).toHaveBeenCalledWith('/watch/paper.pdf', { state: 'missing' }, 'legacy');
   });
 
   it('called without allFiles parameter: deletion-only path (Mode 1 marks missing)', async () => {
@@ -640,7 +641,7 @@ describe('UT-053: WatchFolderService move detection (drag-into-subfolder) — v2
     await service._handleExternalDeletions(new Set());
 
     expect(movedItem.deleted).toBe(false);
-    expect(service._trackingStore.update).toHaveBeenCalledWith('/watch/paper.pdf', { state: 'missing' });
+    expect(service._trackingStore.update).toHaveBeenCalledWith('/watch/paper.pdf', { state: 'missing' }, 'legacy');
   });
 });
 
@@ -1180,7 +1181,7 @@ describe('UT-055: WatchFolderService empty-folder pickup (B.4)', () => {
 
     await service._ensureCollectionsForExistingFolders('/watch');
 
-    expect(relativePathToCollectionMock).toHaveBeenCalledWith('Methods', { createIfMissing: true });
+    expect(relativePathToCollectionMock).toHaveBeenCalledWith('Methods', { createIfMissing: true }, expect.anything());
     const record = service._trackingStore.getCollectionRecord('COL_METHODS');
     expect(record).not.toBe(null);
     // Post-#25: localPath is sync-root-relative.
@@ -1236,8 +1237,8 @@ describe('UT-055: WatchFolderService empty-folder pickup (B.4)', () => {
 
     await service._ensureCollectionsForExistingFolders('/watch');
 
-    expect(relativePathToCollectionMock).toHaveBeenCalledWith('Methods', { createIfMissing: true });
-    expect(relativePathToCollectionMock).toHaveBeenCalledWith('Methods/AI', { createIfMissing: true });
+    expect(relativePathToCollectionMock).toHaveBeenCalledWith('Methods', { createIfMissing: true }, expect.anything());
+    expect(relativePathToCollectionMock).toHaveBeenCalledWith('Methods/AI', { createIfMissing: true }, expect.anything());
   });
 
   it('bails silently when sync root is missing', async () => {
@@ -1339,7 +1340,7 @@ describe('UT-090: cascading-trash protection — _handleExternalDeletions', () =
 
     // Shadow tracking was dropped via .remove(localPath), NOT via
     // .removeByAttachmentKey (which would have collapsed both).
-    expect(store.remove).toHaveBeenCalledWith('A2.pdf');
+    expect(store.remove).toHaveBeenCalledWith('A2.pdf', 'legacy');
     expect(store.removeByAttachmentKey).not.toHaveBeenCalled();
     // Zotero attachment must NOT have been trashed.
     expect(globalThis.Zotero.Items.getByLibraryAndKeyAsync).not.toHaveBeenCalled();
@@ -1396,7 +1397,7 @@ describe('UT-090: cascading-trash protection — _handleExternalDeletions', () =
 
     // Attachment NOT trashed; record kept and flipped to conflict-blocked.
     expect(store.removeByAttachmentKey).not.toHaveBeenCalled();
-    expect(store.update).toHaveBeenCalledWith('A.pdf', { state: 'conflict-blocked' });
+    expect(store.update).toHaveBeenCalledWith('A.pdf', { state: 'conflict-blocked' }, 'legacy');
   });
 
   // ── v2.8.2: diskDeleteSync='ask' disposition (prompt before touching Zotero) ──
@@ -1422,7 +1423,7 @@ describe('UT-090: cascading-trash protection — _handleExternalDeletions', () =
     // 'keep' returns before the trash loop — the Zotero item is never trashed
     // (no record removal) and the file record is flipped to MISSING.
     expect(store.removeByAttachmentKey).not.toHaveBeenCalled();
-    expect(store.update).toHaveBeenCalledWith('A.pdf', { state: 'missing' });
+    expect(store.update).toHaveBeenCalledWith('A.pdf', { state: 'missing' }, 'legacy');
   });
 
   it('diskDeleteSync=ask + Move to Trash → item to Bin (deleted=true, not erased)', async () => {
@@ -3183,7 +3184,9 @@ describe('UT-608: _scan skips the folder-deletion notify when watch root is unav
     fileMissing = await import('../../content/fileMissing.mjs');
     fileMissing.isWatchRootAvailable.mockResolvedValue(true);
     fileScanner = await import('../../content/fileScanner.mjs');
-    fileScanner.scanFolderRecursive.mockResolvedValue([]); // empty scan → no per-file work
+    // scanTree now supplies BOTH the file list and the subdir set for the cycle;
+    // the coordinator's onDiskAbsDirs is built from `dirs`.
+    fileScanner.scanTree.mockResolvedValue({ files: [], dirs: ['/watch/Methods'] });
 
     watchFolderMod = await import('../../content/watchFolder.mjs');
     service = new watchFolderMod.WatchFolderService();
@@ -3221,12 +3224,83 @@ describe('UT-608: _scan skips the folder-deletion notify when watch root is unav
 
     await service._scan();
 
-    expect(service._listSubdirectories).toHaveBeenCalledWith('/watch');
+    // onDiskAbsDirs is derived from scanTree's `dirs` (no separate _listSubdirectories walk).
+    expect(service._listSubdirectories).not.toHaveBeenCalled();
     expect(service._syncCoordinator.notifyScanCycle).toHaveBeenCalledTimes(1);
     const arg = service._syncCoordinator.notifyScanCycle.mock.calls[0][0];
     expect(arg.watchRoot).toBe('/watch');
     expect(arg.onDiskAbsDirs instanceof Set).toBe(true);
     expect(arg.onDiskAbsDirs.has('/watch')).toBe(true);
+    expect(arg.onDiskAbsDirs.has('/watch/Methods')).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// UT-609 (MULTI): _scan iterates EVERY active mapping, not just the first.
+// Regression guard for the "only the first folder is watched" report — the
+// orchestrator loop must call _scanMapping once per mapping each cycle, each
+// with that mapping's own ctx (sourcePath + id).
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('UT-609: _scan polls all configured mappings', () => {
+  let service;
+  let watchFolderMod;
+  let mappingsMod;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    const utils = await import('../../content/utils.mjs');
+    utils.getPref.mockImplementation(() => undefined);
+
+    mappingsMod = await import('../../content/mappings.mjs');
+    watchFolderMod = await import('../../content/watchFolder.mjs');
+    service = new watchFolderMod.WatchFolderService();
+    service._trackingStore = { isDirty: false, save: vi.fn(async () => {}) };
+    globalThis.Zotero.debug = vi.fn();
+    globalThis.Zotero.logError = vi.fn();
+  });
+
+  afterEach(() => {
+    mappingsMod.__test_setActiveMappings(null);
+  });
+
+  it('calls _scanMapping once per mapping, with each mapping ctx', async () => {
+    const A = { id: 'aaaa1111', sourcePath: '/watch/A', scopeMode: 'library', syncRootCollectionKey: '', syncRootLibraryID: 1, mode: 'mode1', pdfStorageStrategy: 'stored' };
+    const B = { id: 'bbbb2222', sourcePath: '/watch/B', scopeMode: 'collection', syncRootCollectionKey: 'COLL1234', syncRootLibraryID: 1, mode: 'mode1', pdfStorageStrategy: 'stored' };
+    const C = { id: 'cccc3333', sourcePath: '/watch/C', scopeMode: 'library', syncRootCollectionKey: '', syncRootLibraryID: 1, mode: 'mode1', pdfStorageStrategy: 'stored' };
+    mappingsMod.__test_setActiveMappings([A, B, C]);
+
+    const seen = [];
+    vi.spyOn(service, '_scanMapping').mockImplementation(async (ctx) => {
+      seen.push({ id: ctx.id, sourcePath: ctx.sourcePath });
+      return 0;
+    });
+
+    await service._scan();
+
+    expect(service._scanMapping).toHaveBeenCalledTimes(3);
+    expect(seen).toEqual([
+      { id: 'aaaa1111', sourcePath: '/watch/A' },
+      { id: 'bbbb2222', sourcePath: '/watch/B' },
+      { id: 'cccc3333', sourcePath: '/watch/C' },
+    ]);
+  });
+
+  it('one mapping throwing does not stop the others from being scanned', async () => {
+    const A = { id: 'aaaa1111', sourcePath: '/watch/A', scopeMode: 'library', syncRootCollectionKey: '', syncRootLibraryID: 1, mode: 'mode1', pdfStorageStrategy: 'stored' };
+    const B = { id: 'bbbb2222', sourcePath: '/watch/B', scopeMode: 'library', syncRootCollectionKey: '', syncRootLibraryID: 1, mode: 'mode1', pdfStorageStrategy: 'stored' };
+    mappingsMod.__test_setActiveMappings([A, B]);
+
+    const seen = [];
+    vi.spyOn(service, '_scanMapping').mockImplementation(async (ctx) => {
+      seen.push(ctx.id);
+      if (ctx.id === 'aaaa1111') throw new Error('boom');
+      return 0;
+    });
+
+    await service._scan();
+
+    expect(seen).toEqual(['aaaa1111', 'bbbb2222']);
   });
 });
 


### PR DESCRIPTION
Proposes the features discussed in #12. Opening as a **draft** for review/discussion — happy to split, rebase, or restructure however suits you.

Contributed from the [ouyangguangqi/zotero-watch-folder](https://github.com/ouyangguangqi/zotero-watch-folder) fork. This is a **feature-only branch off your `main`** — all fork identity/rebrand and version/`update.json` changes are intentionally excluded (add-on id, name, `update_url`, version bumps, etc. are untouched).

## What this adds

### Multiple watch folders
Watch N folders, each mapped to its own target (a specific collection or the whole library) under one global sync mode. "1 folder" is just the list with N=1, so single-root behavior is preserved; a fail-closed migration folds a legacy install into the list. New `content/mappings.mjs` registry + per-mapping context threaded through the scan loop and tracking store.

### Two-way "Mirror without delete" (Mode 2)
Collection renames/moves and item moves propagate both ways between Zotero and the on-disk folder layout; deletions are warn-only. `content/mappingRouter.mjs` attributes each Zotero event to exactly one owning folder via a nearest-ancestor rule (cross-folder isolation). `effectiveGlobalMode()` clamps Mode 3 → Mode 2 in the multi model, so no delete path fires (safe-delete deferred).

### Also
- `fileScanner.scanTree()` — incremental mtime-cached folder walk (idle scans go from O(files) to ~O(dirs), with a periodic full-sweep backstop).
- Trashed/missing sync-target recovery: fail-closed pause + `reconcile` findings + a "Paused — target in Trash/missing" UI state.
- Reworked setup wizard (folder → target → confirm) and folder-list prefs UI; inline Maintenance warnings.

## Safety
- Mode 2 is non-destructive by construction; every deletion path is fail-closed and gated per-mapping.
- Owning-mapping routing keeps folders isolated (an event in folder A never mutates folder B).

## Tests
**1044 passing / 30 files** (new suites: `mappingRouter`, `fileScanner.scanTree`, plus additions across the mirror pipeline). Design + safety model in `docs/mode2-mode3-design.md`.

## Size / structuring
~3.7k lines across 32 files. It is a big change, so I am glad to break it into smaller PRs — e.g. (1) the multi-folder model, then (2) the Mode 2 mirror — or adjust naming/structure to match your preferences.
